### PR TITLE
fix: parseBridge regex for BSI 3.0.0-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@fupete/design-system-italia-mcp",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fupete/design-system-italia-mcp",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -19,10 +19,10 @@
         "@italia/dev-kit-italia": "^1.0.0-alpha.6",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
-        "bootstrap-italia": "^3.0.0-alpha.5",
-        "js-yaml": "^4.1.0",
-        "playwright": "^1.58.2",
-        "tsx": "^4.19.0",
+        "bootstrap-italia": "^3.0.0-beta.1",
+        "js-yaml": "^4.2.0",
+        "playwright": "^1.60.0",
+        "tsx": "^4.22.4",
         "typescript": "^5.7.0"
       },
       "engines": {
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -176,9 +176,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -329,9 +329,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -465,9 +465,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -539,6 +539,25 @@
         "@italia/icon": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/accordion/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/autocomplete": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/autocomplete/-/autocomplete-1.0.0-alpha.12.tgz",
@@ -553,6 +572,25 @@
       },
       "peerDependencies": {
         "@italia/icon": "^1.0.0-alpha.12"
+      }
+    },
+    "node_modules/@italia/autocomplete/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/avatar": {
@@ -571,6 +609,25 @@
         "@italia/icon": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/avatar/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/back-to-top": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/back-to-top/-/back-to-top-1.0.0-alpha.12.tgz",
@@ -581,6 +638,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/back-to-top/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/breadcrumbs": {
@@ -595,6 +671,25 @@
         "lit": "^3.3.0"
       }
     },
+    "node_modules/@italia/breadcrumbs/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/button": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/button/-/button-1.0.0-alpha.12.tgz",
@@ -605,6 +700,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/button/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/callout": {
@@ -622,6 +736,25 @@
         "@italia/collapse": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/callout/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/card": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/card/-/card-1.0.0-alpha.12.tgz",
@@ -632,6 +765,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/card/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/checkbox": {
@@ -645,6 +797,25 @@
         "@italia/i18n": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/checkbox/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/chip": {
@@ -664,6 +835,25 @@
         "@italia/icon": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/chip/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/collapse": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/collapse/-/collapse-1.0.0-alpha.12.tgz",
@@ -674,6 +864,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/collapse/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/dev-kit-italia": {
@@ -732,6 +941,25 @@
         "@italia/popover": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/dropdown/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/globals": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/globals/-/globals-1.0.0-alpha.12.tgz",
@@ -757,6 +985,25 @@
         "lit": "^3.3.0"
       }
     },
+    "node_modules/@italia/hero/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/i18n": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/i18n/-/i18n-1.0.0-alpha.12.tgz",
@@ -779,6 +1026,25 @@
         "lit": "^3.3.0"
       }
     },
+    "node_modules/@italia/icon/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/input": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/input/-/input-1.0.0-alpha.12.tgz",
@@ -795,6 +1061,25 @@
         "@italia/icon": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/input/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/modal": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/modal/-/modal-1.0.0-alpha.12.tgz",
@@ -809,6 +1094,25 @@
       "peerDependencies": {
         "@italia/button": "^1.0.0-alpha.12",
         "@italia/icon": "^1.0.0-alpha.12"
+      }
+    },
+    "node_modules/@italia/modal/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/navscroll": {
@@ -828,6 +1132,25 @@
         "@italia/modal": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/navscroll/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/pagination": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/pagination/-/pagination-1.0.0-alpha.12.tgz",
@@ -838,6 +1161,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.2.1"
+      }
+    },
+    "node_modules/@italia/pagination/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/popover": {
@@ -856,6 +1198,25 @@
         "@italia/button": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/popover/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/radio": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/radio/-/radio-1.0.0-alpha.12.tgz",
@@ -866,6 +1227,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/radio/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/rating": {
@@ -883,6 +1263,25 @@
         "lit": "^3.3.0"
       }
     },
+    "node_modules/@italia/rating/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/section": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/section/-/section-1.0.0-alpha.12.tgz",
@@ -893,6 +1292,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/section/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/select": {
@@ -911,6 +1329,25 @@
         "@italia/icon": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/select/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/skiplinks": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/skiplinks/-/skiplinks-1.0.0-alpha.12.tgz",
@@ -923,6 +1360,25 @@
         "lit": "^3.3.0"
       }
     },
+    "node_modules/@italia/skiplinks/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@italia/sticky": {
       "version": "1.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/@italia/sticky/-/sticky-1.0.0-alpha.12.tgz",
@@ -933,6 +1389,25 @@
         "@italia/globals": "^1.0.0-alpha.12",
         "bootstrap-italia": "3.0.0-beta.0",
         "lit": "^3.3.0"
+      }
+    },
+    "node_modules/@italia/sticky/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
       }
     },
     "node_modules/@italia/video": {
@@ -955,6 +1430,25 @@
         "@italia/icon": "^1.0.0-alpha.12"
       }
     },
+    "node_modules/@italia/video/node_modules/bootstrap-italia": {
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
+      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@popperjs/core": "^2.11.6",
+        "@splidejs/splide": "^4.1.4",
+        "@types/bootstrap": "^5.2.6",
+        "animejs": "^3.2.1",
+        "design-tokens-italia": "^1.3.3",
+        "just-validate": "^4.3.0",
+        "minimasonry": "^1.3.2",
+        "progressbar.js": "^1.1.0",
+        "uuid": "^14.0.0",
+        "video.js": "^8.21.0"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
@@ -973,9 +1467,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1223,9 +1717,9 @@
       }
     },
     "node_modules/bootstrap-italia": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.0.tgz",
-      "integrity": "sha512-6n2n1tIDCMFjLmY0gvXSQ2hoMMMFw6or6euJlB/UHsoyvwHAiuKq7vC03k8kRi0m7hL9HW5FsuW+zvj8tOOptw==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-italia/-/bootstrap-italia-3.0.0-beta.1.tgz",
+      "integrity": "sha512-R17xY+24FVkXm2YT3FBfxhOOMERft1vQHj6TZuX7uXD5vKUd3Xjv+QQt/2vMFf4aGsYmRPyt0lWt8sVapoGcAA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1238,21 +1732,7 @@
         "minimasonry": "^1.3.2",
         "progressbar.js": "^1.1.0",
         "uuid": "^14.0.0",
-        "video.js": "^8.21.0"
-      }
-    },
-    "node_modules/bootstrap-italia/node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "video.js": "^8.23.7"
       }
     },
     "node_modules/bytes": {
@@ -1473,9 +1953,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1486,32 +1966,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escape-html": {
@@ -1733,19 +2213,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/global": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
@@ -1891,10 +2358,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2189,13 +2666,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2208,9 +2685,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2315,16 +2792,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/router": {
@@ -2522,14 +2989,13 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -2583,6 +3049,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fupete/design-system-italia-mcp",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Filo – MCP server non ufficiale per il Design system .italia",
   "type": "module",
   "main": "dist/index.js",
@@ -39,18 +39,18 @@
     "url": "https://github.com/Fupete/design-system-italia-mcp.git"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
-    "js-yaml": "^4.1.0",
-    "playwright": "^1.58.2",
-    "tsx": "^4.19.0",
+    "js-yaml": "^4.2.0",
+    "playwright": "^1.60.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.7.0",
     "@italia/dev-kit-italia": "^1.0.0-alpha.6",
-    "bootstrap-italia": "^3.0.0-alpha.5"
+    "bootstrap-italia": "^3.0.0-beta.1"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,8 +1,8 @@
 publiccodeYmlVersion: "0.5.0"
 name: design-system-italia-mcp
 url: "https://github.com/fupete/design-system-italia-mcp"
-softwareVersion: "0.3.11"
-releaseDate: "2026-04-08"
+softwareVersion: "0.3.12"
+releaseDate: "2026-06-10"
 softwareType: addon
 platforms:
   - web

--- a/src/loaders/tokens.ts
+++ b/src/loaders/tokens.ts
@@ -4,10 +4,10 @@ import type { CssToken } from '../types.js'
 import { SNAPSHOT_DTI_VARIABLES_SCSS_URL, SNAPSHOT_BSI_ROOT_SCSS_URL, SNAPSHOT_BSI_CUSTOM_PROPERTIES_URL, } from '../constants.js'
 
 // Map 1: --bsi-* component tokens (custom-properties.json) — token-reference entries only
-// Map 2: --bsi-* → --it-* bridge (BSI scss/base/root.scss v3)
+// Map 2: --bsi-* → --it-* bridge (BSI _root.scss v3 — Sass compile-time via #{tokens.$it-*})
 // Map 3: --it-* → value or --it-* reference (design-tokens-italia > _variables.scss)
 //
-// Resolution chain: --bsi-accordion-padding → --bsi-spacing-m → --it-spacing-m → 1.5rem (24px)
+// Resolution chain: --bsi-accordion-padding → --bsi-spacing-m → --it-spacing-m → --it-spacing-6x → 24px
 
 // ─── Parsers ──────────────────────────────────────────────────────────────────
 
@@ -33,14 +33,14 @@ function parseDesignTokens(scss: string): DtiMap {
   return map
 }
 
-// Format: --#{$prefix}spacing-m: var(--it-spacing-m);
+// Format: --#{$prefix}spacing-m: #{tokens.$it-spacing-m};
 function parseBridge(scss: string): BridgeMap {
   const map: BridgeMap = new Map()
   for (const line of scss.split('\n')) {
-    const match = line.match(/--#\{\$prefix\}([a-z0-9-]+):\s*var\((--it-[a-z0-9-]+)\)/)
+    const match = line.match(/--#\{\$prefix\}([a-z0-9-]+):\s*#\{tokens\.\$it-([a-z0-9-]+)\}/)
     if (!match) continue
-    const [, bsiSuffix, itName] = match
-    map.set(`--bsi-${bsiSuffix}`, itName)
+    const [, bsiSuffix, itSuffix] = match
+    map.set(`--bsi-${bsiSuffix}`, `--it-${itSuffix}`)
   }
   return map
 }


### PR DESCRIPTION
Fix #48 

BSI 3.0.0-beta.1 migrated `_root.scss` from runtime CSS custom properties
(`var(--it-*)`) to Sass compile-time interpolation (`#{tokens.$it-*}`),
breaking `parseBridge` and causing `valueResolved: null` on all component tokens.

## Changes
- `parseBridge` regex updated for new Sass interpolation format
- Updated comments in `tokens.ts` to reflect 3.x bridge format
- `bootstrap-italia` bumped to `3.0.0-beta.1`
- `@modelcontextprotocol/sdk` bumped to `1.29.0`
- `js-yaml`, `tsx`, `playwright` bumped to latest minor

## Tested
- `get_component_tokens("accordion")` → `valueResolved` non null on all resolvable token-references
- Canary 15/15 ✅