### PR TITLE
WA3 (3/5): Docs/GitHub tool rename

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,9 @@ import { registerDsiListComponents } from './tools/dsi-list-components.js'
 import { registerDsiSearchComponents } from './tools/dsi-search-components.js'
 import { registerGetComponentTokens } from './tools/get-component-tokens.js' 
 import { registerFindToken } from './tools/find-token.js'
-import { registerGetComponentGuidelines } from './tools/get-component-guidelines.js'
-import { registerGetComponentIssues } from './tools/get-component-issues.js'
-import { registerGetProjectBoardStatus } from './tools/get-project-board-status.js' 
+import { registerDocsGetComponentGuide } from './tools/docs-get-component-guide.js'
+import { registerGithubGetComponentIssues } from './tools/github-get-component-issues.js'
+import { registerGithubGetProjectRepoLinks } from './tools/github-get-project-repo-links.js'
 import { registerBsiListComponentVariants } from './tools/bsi-list-component-variants.js'
 import { registerBsiGetComponentMarkup } from './tools/bsi-get-component-markup.js'
 import { registerDevkitListComponentVariants } from './tools/devkit-list-component-variants.js'
@@ -76,10 +76,10 @@ function createMcpServer(): McpServer {
                 'devkit_get_component_markup',
                 'devkit_list_component_props',
                 'bsi_list_components_by_status',
-                'get_component_guidelines',
-                'get_component_issues',
+                'docs_get_component_guide',
+                'github_get_component_issues',
                 'get_component_tokens',
-                'get_project_board_status',
+                'github_get_project_repo_links',
                 'dsi_list_components',
                 'dsi_search_components',
               ],
@@ -94,11 +94,13 @@ function createMcpServer(): McpServer {
 
   registerFindToken(s)
 
-  registerGetComponentGuidelines(s)
-  registerGetComponentIssues(s)
+
+  registerDocsGetComponentGuide(s)
+
   registerGetComponentTokens(s)
 
-  registerGetProjectBoardStatus(s)
+  registerGithubGetComponentIssues(s)
+  registerGithubGetProjectRepoLinks(s)
 
   registerBsiListComponentVariants(s)
   registerBsiGetComponentMarkup(s)

--- a/src/loaders/github.ts
+++ b/src/loaders/github.ts
@@ -97,6 +97,6 @@ export function getProjectBoardStatus(): BoardStatus {
     note:
       'GitHub Projects v2 board (project #17) not integrated — ' +
       'requires read:project scope. ' +
-      'Use get_component_issues for component-specific issues.',
+      'Use github_get_component_issues for component-specific issues.',
   }
 }

--- a/src/tools/docs-get-component-guide.ts
+++ b/src/tools/docs-get-component-guide.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
-import { loadAllStatuses, loadStatus } from '../loaders/bsi.js'
+import { loadStatus } from '../loaders/bsi.js'
 import { loadGuidelines, designersUrl } from '../loaders/designers.js'
 import { loadDevKitEntry } from '../loaders/devkit.js'
 import { slugify } from '../slugify.js'
@@ -8,13 +8,13 @@ import { loadDsMeta } from '../loaders/meta.js'
 import { buildMeta } from './helpers.js'
 import { ALPHA_WARNING, BSI_STATUS_URL, DESIGNERS_COMPONENT_URL, DEVKIT_INDEX_URL } from '../constants.js'
 
-// ─── Tool: get_component_guidelines ──────────────────────────────────────────
+// ─── Tool: docs_get_component_guide ───────────────────────────────────────────
 
-export function registerGetComponentGuidelines(server: McpServer): void {
+export function registerDocsGetComponentGuide(server: McpServer): void {
   server.registerTool(
-    'get_component_guidelines',
+    'docs_get_component_guide',
     {
-      title: 'Get Component Guidelines',
+      title: 'Get Component Guide',
       description: 'Returns usage guidelines for a component from Designers Italia website: ' +
         'when to use it, how to use it, recommended alternatives, accessibility notes ' +
         'and library status (Bootstrap Italia, UI Kit Italia, ...).',

--- a/src/tools/docs-get-component-guide.ts
+++ b/src/tools/docs-get-component-guide.ts
@@ -18,12 +18,12 @@ export function registerDocsGetComponentGuide(server: McpServer): void {
       description: 'Returns usage guidelines for a component from Designers Italia website: ' +
         'when to use it, how to use it, recommended alternatives, accessibility notes ' +
         'and library status (Bootstrap Italia, UI Kit Italia, ...).',
-      inputSchema: { name: z.string().describe('Component name or slug (e.g. "accordion", "Alert")') },
+      inputSchema: { component: z.string().describe('Component name or slug (e.g. "accordion", "Alert")') },
       annotations: { readOnlyHint: true },
     },
-    async ({ name }) => {
-      name = name.trim()
-      const slug = slugify(name)
+    async ({ component }) => {
+      component = component.trim()
+      const slug = slugify(component)
       const warnings: string[] = []
 
       const [guidelines, status, devKitEntry, dsMeta] = await Promise.all([

--- a/src/tools/github-get-component-issues.ts
+++ b/src/tools/github-get-component-issues.ts
@@ -1,17 +1,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { formatTimestamp } from '../utils.js'
-import { loadComponentIssues, getProjectBoardStatus } from '../loaders/github.js'
+import { loadComponentIssues } from '../loaders/github.js'
 import { loadStatus } from '../loaders/bsi.js'
 import { slugify } from '../slugify.js'
 import { GITHUB_SEARCH_ISSUES_URL, GITHUB_WATCHED_REPOS, BSI_STATUS_URL } from '../constants.js'
 import { buildMeta } from './helpers.js'
 
-// ─── Tool: get_component_issues ───────────────────────────────────────────────
+// ─── Tool: github_get_component_issues ────────────────────────────────────────
 
-export function registerGetComponentIssues(server: McpServer): void {
+export function registerGithubGetComponentIssues(server: McpServer): void {
   server.registerTool(
-    'get_component_issues',
+    'github_get_component_issues',
     {
       title: 'Get Component Issues',
       description: 'Returns open GitHub issues for a component ' +

--- a/src/tools/github-get-component-issues.ts
+++ b/src/tools/github-get-component-issues.ts
@@ -18,12 +18,12 @@ export function registerGithubGetComponentIssues(server: McpServer): void {
         'across the 4 Design System .italia repositories: bootstrap-italia, ' +
         'design-ui-kit, dev-kit-italia, design-tokens-italia. ' +
         'Also includes known issues already present in components_status.json.',
-      inputSchema: { name: z.string().describe('Component name or slug (e.g. "accordion", "Alert")') },
+      inputSchema: { component: z.string().describe('Component name or slug (e.g. "accordion", "Alert")') },
       annotations: { readOnlyHint: true },
     },
-    async ({ name }) => {
-      name = name.trim()
-      const slug = slugify(name)
+    async ({ component }) => {
+      component = component.trim()
+      const slug = slugify(component)
       const warnings: string[] = []
 
       const [{ issues: liveIssues, error: issuesError }, status] = await Promise.all([

--- a/src/tools/github-get-project-repo-links.ts
+++ b/src/tools/github-get-project-repo-links.ts
@@ -2,16 +2,18 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { formatTimestamp } from '../utils.js'
 import { getProjectBoardStatus } from '../loaders/github.js'
 
-// ─── Tool: get_project_board_status ───────────────────────────────────────────
+// ─── Tool: github_get_project_repo_links ──────────────────────────────────────
+// Repo issue links, not live board card data — GitHub Projects v2 board
+// (project #17) is not integrated (requires read:project scope).
 
-export function registerGetProjectBoardStatus(server: McpServer): void {
+export function registerGithubGetProjectRepoLinks(server: McpServer): void {
   server.registerTool(
-    'get_project_board_status',
+    'github_get_project_repo_links',
     {
-      title: 'Get Project Board Status',
-      description: 'Returns the aggregated status of Design System .italia GitHub boards. ' +
-        'Includes links to open issues for each repository.' +
-        'use get_component_issues for component-specific issues.',
+      title: 'Get Project Repo Links',
+      description: 'Returns links to open issues for each Design System .italia repository. ' +
+        'Does not include live GitHub Projects v2 board card data (not integrated). ' +
+        'Use github_get_component_issues for component-specific issues.',
       inputSchema: {},
       annotations: { readOnlyHint: true },
     },


### PR DESCRIPTION
Part 5 of the WA3 block (v0.4.0 breaking rename). Builds on `refactor/wa3-bsi-devkit-split` (PR2) — branched from it, not from `main`.

## What changes

- `get_component_guidelines` -> `docs_get_component_guide`
- `get_component_issues` -> `github_get_component_issues`
- `get_project_board_status` -> `github_get_project_repo_links` — renamed to be honest about scope: this returns repo issue links, not live GitHub Projects v2 board card data (board #17 integration requires
  `read:project scope`, not implemented)
- Updated the cross-referencing note in the shared `github.ts` loader (`getProjectBoardStatus()`'s note field pointed to the old tool name)
- Removed two dead imports found along the way: `loadAllStatuses` in the docs tool, `getProjectBoardStatus` in the issues tool — neither was actually used in either file
- `index.ts`: `ping` payload tools array updated accordingly

## Not included in this PR

Tokens 8->5 collapse, alpha->beta sweep, mini-site, programmatically derived `ping` array — follow in separate PRs.

## Verification

- [x] `npm run typecheck` clean
- [x] `npm run canary` 16/16
- [x] Functional checks via MCP Inspector CLI:
  - `docs_get_component_guide(name: "accordion")` — full guidelines content, sourceUrls unchanged
  - `github_get_project_repo_links()` — note field correctly references `github_get_component_issues` (confirms github.ts update landed)
  - `github_get_component_issues(name: "accordion")` — live GitHub search works, 3 issues found, dedup against known issues correct