### PR TITLE
WA3 (4/5): Tokens 8->5 collapse, closes $it- gate

### DIFF
--- a/scripts/canary.config.ts
+++ b/scripts/canary.config.ts
@@ -30,8 +30,11 @@ import {
   SNAPSHOT_BSI_STATUS_URL,
   SNAPSHOT_DEVKIT_INDEX_URL,
   SNAPSHOT_BSI_CUSTOM_PROPERTIES_URL,
+  SNAPSHOT_BSI_ROOT_SCSS_URL,
+  SNAPSHOT_DTI_VARIABLES_SCSS_URL,
   GITHUB_CONTENTS_DEVKIT_STORIES_URL,
 } from "../src/constants.js";
+import { parseBridge, parseDesignTokens } from "../src/loaders/tokens.js";
 
 // ── Shared result type ────────────────────────────────────────────────────────
 
@@ -250,37 +253,35 @@ export const SNAPSHOT_FRESHNESS: PipelineCheck[] = [
     },
   },
   {
-    name: "[upstream] $it- bridge chain resolves (spacing-m)",
-    async run({ get }) {
-      const t0 = Date.now();
-      const [rootRes, varsRes] = await Promise.all([
-        get(BSI_ROOT_SCSS_URL),
-        get(DTI_VARIABLES_SCSS_URL),
-      ]);
-      if (!rootRes.ok) return { url: BSI_ROOT_SCSS_URL, ok: false, ms: Date.now() - t0, error: `HTTP ${rootRes.status}` };
-      if (!varsRes.ok) return { url: DTI_VARIABLES_SCSS_URL, ok: false, ms: Date.now() - t0, error: `HTTP ${varsRes.status}` };
+  name: "[snapshot] \$it- bridge chain resolves (spacing-m)",
+  async run({ get }) {
+    const t0 = Date.now();
+    const [rootRes, varsRes] = await Promise.all([
+      get(SNAPSHOT_BSI_ROOT_SCSS_URL),
+      get(SNAPSHOT_DTI_VARIABLES_SCSS_URL),
+    ]);
+    if (!rootRes.ok) return { url: SNAPSHOT_BSI_ROOT_SCSS_URL, ok: false, ms: Date.now() - t0, error: `HTTP ${rootRes.status}` };
+    if (!varsRes.ok) return { url: SNAPSHOT_DTI_VARIABLES_SCSS_URL, ok: false, ms: Date.now() - t0, error: `HTTP ${varsRes.status}` };
 
-      // Same regex as parseBridge() in src/loaders/tokens.ts — keep in sync if that changes.
-      const bridgeMatch = rootRes.body.match(/--#\{\$prefix\}spacing-m:\s*#\{tokens\.\$it-([a-z0-9-]+)\}/);
-      if (!bridgeMatch) {
-        return {
-          url: BSI_ROOT_SCSS_URL, ok: false, ms: Date.now() - t0,
-          error: "bridge entry for spacing-m not found — parseBridge() may be out of sync with root.scss format",
-        };
-      }
-      const itName = `it-${bridgeMatch[1]}`;
+    const bridge = parseBridge(rootRes.body);
+    const dti = parseDesignTokens(varsRes.body);
 
-      // Same regex as parseDesignTokens() in src/loaders/tokens.ts
-      const dtiMatch = varsRes.body.match(new RegExp(`^\\$${itName}:\\s*([^;]+);`, "m"));
-      if (!dtiMatch) {
-        return {
-          url: DTI_VARIABLES_SCSS_URL, ok: false, ms: Date.now() - t0,
-          error: `$${itName} not found in _variables.scss — chain breaks after bridge`,
-        };
-      }
-      return { url: DTI_VARIABLES_SCSS_URL, ok: true, ms: Date.now() - t0 };
-    },
+    const itName = bridge.get("--bsi-spacing-m");
+    if (!itName) {
+      return {
+        url: SNAPSHOT_BSI_ROOT_SCSS_URL, ok: false, ms: Date.now() - t0,
+        error: "bridge entry for --bsi-spacing-m not found in snapshot — parseBridge() may be out of sync with root.scss format",
+      };
+    }
+    if (!dti.has(itName)) {
+      return {
+        url: SNAPSHOT_DTI_VARIABLES_SCSS_URL, ok: false, ms: Date.now() - t0,
+        error: `${itName} not found in snapshot _variables.scss — chain breaks after bridge`,
+      };
+    }
+    return { url: SNAPSHOT_DTI_VARIABLES_SCSS_URL, ok: true, ms: Date.now() - t0 };
   },
+},
 ];
 
 // ── Legacy exports for canary.ts compatibility ────────────────────────────────

--- a/scripts/canary.config.ts
+++ b/scripts/canary.config.ts
@@ -249,6 +249,38 @@ export const SNAPSHOT_FRESHNESS: PipelineCheck[] = [
       return { url: SNAPSHOT_BSI_CUSTOM_PROPERTIES_URL, ok: true, ms: Date.now() - t0 };
     },
   },
+  {
+    name: "[upstream] $it- bridge chain resolves (spacing-m)",
+    async run({ get }) {
+      const t0 = Date.now();
+      const [rootRes, varsRes] = await Promise.all([
+        get(BSI_ROOT_SCSS_URL),
+        get(DTI_VARIABLES_SCSS_URL),
+      ]);
+      if (!rootRes.ok) return { url: BSI_ROOT_SCSS_URL, ok: false, ms: Date.now() - t0, error: `HTTP ${rootRes.status}` };
+      if (!varsRes.ok) return { url: DTI_VARIABLES_SCSS_URL, ok: false, ms: Date.now() - t0, error: `HTTP ${varsRes.status}` };
+
+      // Same regex as parseBridge() in src/loaders/tokens.ts — keep in sync if that changes.
+      const bridgeMatch = rootRes.body.match(/--#\{\$prefix\}spacing-m:\s*#\{tokens\.\$it-([a-z0-9-]+)\}/);
+      if (!bridgeMatch) {
+        return {
+          url: BSI_ROOT_SCSS_URL, ok: false, ms: Date.now() - t0,
+          error: "bridge entry for spacing-m not found — parseBridge() may be out of sync with root.scss format",
+        };
+      }
+      const itName = `it-${bridgeMatch[1]}`;
+
+      // Same regex as parseDesignTokens() in src/loaders/tokens.ts
+      const dtiMatch = varsRes.body.match(new RegExp(`^\\$${itName}:\\s*([^;]+);`, "m"));
+      if (!dtiMatch) {
+        return {
+          url: DTI_VARIABLES_SCSS_URL, ok: false, ms: Date.now() - t0,
+          error: `$${itName} not found in _variables.scss — chain breaks after bridge`,
+        };
+      }
+      return { url: DTI_VARIABLES_SCSS_URL, ok: true, ms: Date.now() - t0 };
+    },
+  },
 ];
 
 // ── Legacy exports for canary.ts compatibility ────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,11 @@ import { createRequire } from 'node:module'
 // ─── Tools ───────────────────────────────────────────────────────────────────
 import { registerDsiListComponents } from './tools/dsi-list-components.js'
 import { registerDsiSearchComponents } from './tools/dsi-search-components.js'
-import { registerGetComponentTokens } from './tools/get-component-tokens.js' 
-import { registerFindToken } from './tools/find-token.js'
+import { registerTokensListComponentVars } from './tools/tokens-list-component-vars.js'
+import { registerTokensListGlobals } from './tools/tokens-list-globals.js'
+import { registerTokensResolve } from './tools/tokens-resolve.js'
+import { registerTokensFindComponents } from './tools/tokens-find-components.js'
+import { registerTokensSearch } from './tools/tokens-search.js'
 import { registerDocsGetComponentGuide } from './tools/docs-get-component-guide.js'
 import { registerGithubGetComponentIssues } from './tools/github-get-component-issues.js'
 import { registerGithubGetProjectRepoLinks } from './tools/github-get-project-repo-links.js'
@@ -69,7 +72,11 @@ function createMcpServer(): McpServer {
               warnings: ALPHA_WARNING,
               tools: [
                 'ping',
-                'find_token',
+                'tokens_list_component_vars',
+                'tokens_list_globals',
+                'tokens_resolve',
+                'tokens_find_components',
+                'tokens_search',
                 'bsi_list_component_variants',
                 'bsi_get_component_markup',
                 'devkit_list_component_variants',
@@ -78,7 +85,6 @@ function createMcpServer(): McpServer {
                 'bsi_list_components_by_status',
                 'docs_get_component_guide',
                 'github_get_component_issues',
-                'get_component_tokens',
                 'github_get_project_repo_links',
                 'dsi_list_components',
                 'dsi_search_components',
@@ -92,18 +98,20 @@ function createMcpServer(): McpServer {
     })
   )
 
-  registerFindToken(s)
-
+  registerTokensListComponentVars(s)
+  registerTokensListGlobals(s)
+  registerTokensResolve(s)
+  registerTokensFindComponents(s)
+  registerTokensSearch(s)
 
   registerDocsGetComponentGuide(s)
-
-  registerGetComponentTokens(s)
 
   registerGithubGetComponentIssues(s)
   registerGithubGetProjectRepoLinks(s)
 
   registerBsiListComponentVariants(s)
   registerBsiGetComponentMarkup(s)
+
   registerDevkitListComponentVariants(s)
   registerDevkitGetComponentMarkup(s)
   registerDevkitListComponentProps(s)

--- a/src/loaders/bsi.ts
+++ b/src/loaders/bsi.ts
@@ -129,13 +129,13 @@ export async function loadVariantsResolvedSlug(slug: string): Promise<string> {
 type RawTokenEntry = { 'variable-name': string; value: string; description: string }
 type RawTokensJson = Record<string, RawTokenEntry[]>
 
-function classifyValue(value: string): CssToken['valueType'] {
+export function classifyValue(value: string): CssToken['valueType'] {
   if (value.startsWith('#{') || value.startsWith('escape-svg(')) return 'scss-expression'
   if (value.startsWith('var(')) return 'token-reference'
   return 'literal'
 }
 
-async function loadAllTokens(): Promise<RawTokensJson> {
+export async function loadAllTokens(): Promise<RawTokensJson> {
   const cached = cache.get<RawTokensJson>(CACHE_KEYS.bsiTokens())
   if (cached) return cached
 

--- a/src/loaders/tokens.test.ts
+++ b/src/loaders/tokens.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { normalizeTokenName, roleFor, hopFor } from './tokens.js'
+import type { DtiMap, BridgeMap } from './tokens.js'
+
+// ─── normalizeTokenName ─────────────────────────────────────────────────────
+
+describe('normalizeTokenName', () => {
+  it('passes through --bsi-* unchanged', () => {
+    assert.equal(normalizeTokenName('--bsi-spacing-m'), '--bsi-spacing-m')
+  })
+
+  it('passes through --it-* unchanged', () => {
+    assert.equal(normalizeTokenName('--it-spacing-m'), '--it-spacing-m')
+  })
+
+  it('converts $it-* to --it-*', () => {
+    assert.equal(normalizeTokenName('$it-spacing-m'), '--it-spacing-m')
+  })
+
+  it('extracts from var(--bsi-x)', () => {
+    assert.equal(normalizeTokenName('var(--bsi-spacing-m)'), '--bsi-spacing-m')
+  })
+
+  it('extracts from var(--bsi-x, fallback) — with a fallback value', () => {
+    assert.equal(normalizeTokenName('var(--bsi-spacing-m, 1rem)'), '--bsi-spacing-m')
+  })
+
+  it('extracts from var( --bsi-x ) — extra whitespace after the paren', () => {
+    assert.equal(normalizeTokenName('var( --bsi-spacing-m )'), '--bsi-spacing-m')
+  })
+
+  it('extracts from #{tokens.$it-x} — Sass compile-time interpolation form', () => {
+    assert.equal(normalizeTokenName('#{tokens.$it-spacing-m}'), '--it-spacing-m')
+  })
+
+  it('extracts from tokens.$it-x — same form without interpolation braces', () => {
+    assert.equal(normalizeTokenName('tokens.$it-spacing-m'), '--it-spacing-m')
+  })
+
+  it('is case-insensitive', () => {
+    assert.equal(normalizeTokenName('--BSI-Spacing-M'), '--bsi-spacing-m')
+    assert.equal(normalizeTokenName('$IT-Spacing-M'), '--it-spacing-m')
+  })
+
+  it('adds -- prefix to a bare name', () => {
+    assert.equal(normalizeTokenName('bsi-spacing-m'), '--bsi-spacing-m')
+    assert.equal(normalizeTokenName('it-spacing-m'), '--it-spacing-m')
+  })
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(normalizeTokenName('  --bsi-spacing-m  '), '--bsi-spacing-m')
+  })
+})
+
+// ─── roleFor / hopFor ───────────────────────────────────────────────────────
+
+describe('roleFor — dtiRaw as primary discriminant', () => {
+  it('classifies a --it-* name as dti', () => {
+    const dtiRaw: DtiMap = new Map([['--it-spacing-m', '1.5rem']])
+    const bridge: BridgeMap = new Map()
+    assert.equal(roleFor('--it-spacing-m', dtiRaw, bridge), 'dti')
+  })
+
+  it('classifies a dtiRaw key WITHOUT the it- prefix as dti — not bsi-component', () => {
+    // parseDesignTokens maps ANY $foo: to --foo, not only $it-foo. A prefix-only
+    // check would misclassify this as bsi-component (overridable: true), which
+    // is exactly the false claim T-MANIP exists to prevent.
+    const dtiRaw: DtiMap = new Map([['--custom-shadow-token', '0 2px 4px black']])
+    const bridge: BridgeMap = new Map()
+    assert.equal(roleFor('--custom-shadow-token', dtiRaw, bridge), 'dti')
+  })
+
+  it('classifies a --bsi-* bridge key as bsi-global', () => {
+    const dtiRaw: DtiMap = new Map()
+    const bridge: BridgeMap = new Map([['--bsi-spacing-m', '--it-spacing-m']])
+    assert.equal(roleFor('--bsi-spacing-m', dtiRaw, bridge), 'bsi-global')
+  })
+
+  it('classifies any other --bsi-* as bsi-component', () => {
+    const dtiRaw: DtiMap = new Map()
+    const bridge: BridgeMap = new Map()
+    assert.equal(roleFor('--bsi-accordion-padding', dtiRaw, bridge), 'bsi-component')
+  })
+})
+
+describe('hopFor — sourceName and form', () => {
+  it('a dti hop exposes the $it- Sass source form and overridable: false', () => {
+    const dtiRaw: DtiMap = new Map([['--it-spacing-6x', '24px']])
+    const bridge: BridgeMap = new Map()
+    const hop = hopFor('--it-spacing-6x', dtiRaw, bridge)
+    assert.equal(hop.sourceName, '$it-spacing-6x')
+    assert.equal(hop.form, 'sass-variable')
+    assert.equal(hop.overridable, false)
+  })
+
+  it('a bsi hop exposes itself as the source and overridable: true', () => {
+    const dtiRaw: DtiMap = new Map()
+    const bridge: BridgeMap = new Map([['--bsi-spacing-m', '--it-spacing-m']])
+    const hop = hopFor('--bsi-spacing-m', dtiRaw, bridge)
+    assert.equal(hop.sourceName, '--bsi-spacing-m')
+    assert.equal(hop.form, 'css-custom-property')
+    assert.equal(hop.overridable, true)
+  })
+})

--- a/src/loaders/tokens.ts
+++ b/src/loaders/tokens.ts
@@ -15,8 +15,8 @@ import { SNAPSHOT_DTI_VARIABLES_SCSS_URL, SNAPSHOT_BSI_ROOT_SCSS_URL, SNAPSHOT_B
 // parsing logic the server uses, instead of a duplicated regex that can drift
 // out of sync (this drift is what caused the v0.3.12 root.scss bug).
 
-type DtiMap = Map<string, string>     // --it-* → value or --it-* reference
-type BridgeMap = Map<string, string>  // --bsi-* → --it-* (root.scss)
+export type DtiMap = Map<string, string>     // --it-* → value or --it-* reference
+export type BridgeMap = Map<string, string>  // --bsi-* → --it-* (root.scss)
 type BsiMap = Map<string, string>     // --bsi-* → --bsi-* or --it-* (custom-properties.json, token-reference only)
 
 // Format: $it-spacing-m: 1.5rem; // 24px
@@ -73,17 +73,17 @@ function parseBsiMap(raw: RawTokensJson): BsiMap {
 // "bsi-component" (per-component custom-properties.json entry); anything
 // --it-* is "dti" (central Design Token, not overridable per-project).
 
-function roleFor(name: string, bridge: BridgeMap): TokenRole {
-  if (name.startsWith('--it-')) return 'dti'
+export function roleFor(name: string, dtiRaw: DtiMap, bridge: BridgeMap): TokenRole {
+  if (dtiRaw.has(name)) return 'dti'
   if (bridge.has(name)) return 'bsi-global'
   return 'bsi-component'
 }
 
-function hopFor(name: string, bridge: BridgeMap): ResolvedHop {
-  const role = roleFor(name, bridge)
+export function hopFor(name: string, dtiRaw: DtiMap, bridge: BridgeMap): ResolvedHop {
+  const role = roleFor(name, dtiRaw, bridge)
   return {
     name,
-    sourceName: role === 'dti' ? `$${name.slice(2)}` : name,
+    sourceName: role === 'dti' ? `$${name.replace(/^--/, '')}` : name,
     form: role === 'dti' ? 'sass-variable' : 'css-custom-property',
     role,
     overridable: role !== 'dti',
@@ -116,7 +116,7 @@ function resolveChain(
     const next = bsiMap.get(name) ?? bridge.get(name)
     if (!next) return { value: null, chain: [] }
     const result = resolveChain(next, bsiMap, bridge, dtiRaw, visited)
-    return { value: result.value, chain: [hopFor(next, bridge), ...result.chain] }
+    return { value: result.value, chain: [hopFor(next, dtiRaw, bridge), ...result.chain] }
   }
 
   // --it-* → follow dtiRaw
@@ -125,7 +125,7 @@ function resolveChain(
     if (!val) return { value: null, chain: [] }
     if (val.startsWith('--it-')) {
       const result = resolveChain(val, bsiMap, bridge, dtiRaw, visited)
-      return { value: result.value, chain: [hopFor(val, bridge), ...result.chain] }
+      return { value: result.value, chain: [hopFor(val, dtiRaw, bridge), ...result.chain] }
     }
     return { value: val, chain: [] }
   }
@@ -195,7 +195,7 @@ export async function resolveTokenValues(tokens: CssToken[]): Promise<CssToken[]
     // a different component's value (last write wins). Starting from `ref`
     // sidesteps that ambiguity entirely.
     const { value, chain } = resolveChain(ref, maps.bsiMap, maps.bridge, maps.dtiRaw)
-    return { ...token, valueResolved: value, resolvedVia: [hopFor(ref, maps.bridge), ...chain] }
+    return { ...token, valueResolved: value, resolvedVia: [hopFor(ref, maps.dtiRaw, maps.bridge), ...chain] }
   })
 }
 
@@ -226,15 +226,20 @@ export async function searchDesignTokens(
 // property). Everything downstream (bridge, dtiRaw) already keys on --it-*,
 // so $it-* just needs converting before the first lookup.
 
-function normalizeTokenName(input: string): string {
-  const trimmed = input.trim()
-  // var(--bsi-accordion-padding) — the exact value field the model just read
-  // from tokens_list_component_vars, likely the single most common input.
-  const varMatch = trimmed.match(/^var\((--[a-z0-9-]+)\)/)
+export function normalizeTokenName(input: string): string {
+  const trimmed = input.trim().toLowerCase()
+
+  // #{tokens.$it-spacing-m} or tokens.$it-spacing-m — Sass source forms
+  // copied directly from root.scss, the same source the $it- gate targets.
+  const tokensDotMatch = trimmed.match(/tokens\.\$it-([a-z0-9-]+)/)
+  if (tokensDotMatch) return `--it-${tokensDotMatch[1]}`
+
+  // var(--bsi-x) or var(--bsi-x, fallback) — allow a fallback after the name
+  const varMatch = trimmed.match(/^var\(\s*(--[a-z0-9-]+)/)
   if (varMatch) return varMatch[1]
+
   if (trimmed.startsWith('$')) return `--${trimmed.slice(1)}`
   if (trimmed.startsWith('--bsi-') || trimmed.startsWith('--it-')) return trimmed
-  // Defensive: bare name without -- prefix (e.g. "it-spacing-m", "bsi-accordion-padding")
   if (trimmed.startsWith('it-') || trimmed.startsWith('bsi-')) return `--${trimmed}`
   return trimmed
 }
@@ -279,16 +284,13 @@ export interface ResolveTokenResult {
 export async function resolveToken(input: string): Promise<ResolveTokenResult> {
   const name = normalizeTokenName(input)
   const { bsiMap, bridge, dtiRaw } = await loadMaps()
-  const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
 
-  if (value !== null) {
-    return { name, value, resolvedVia: chain }
-  }
-
-  // Fallback: name may be a literal --bsi-* value (e.g. "0", "1px"), which
-  // parseBsiMap never indexes because it only captures token-reference
-  // entries. Search the raw per-component data directly instead of
-  // declaring a token that genuinely exists "not found".
+  // For --bsi-* names, check ambiguity across ALL declarations first — a
+  // primary chain resolution via bsiMap (last-write-wins) can silently
+  // return a plausible-looking wrong value if this variable-name is
+  // declared multiple times with different values (e.g. per-component
+  // responsive/theme variants). Ambiguity must be decided before attempting
+  // resolution, not just as a fallback triggered when resolution fails.
   if (name.startsWith('--bsi-')) {
     const allTokens = await loadAllTokens()
     const matches: Array<{ component: string; value: string; type: ReturnType<typeof classifyValue> }> = []
@@ -300,33 +302,41 @@ export async function resolveToken(input: string): Promise<ResolveTokenResult> {
       }
     }
 
-    const literals = matches.filter((m) => m.type === 'literal')
-    const distinctLiteralValues = new Set(literals.map((m) => m.value))
+    if (matches.length > 0) {
+      const distinctValues = new Set(matches.map((m) => m.value))
 
-    if (distinctLiteralValues.size === 1 && matches.length === literals.length) {
-      return { name, value: literals[0].value, resolvedVia: [] }
-    }
-    if (distinctLiteralValues.size > 1) {
-      return {
-        name, value: null, resolvedVia: [],
-        ambiguous: matches.map(({ component, value }) => ({ component, value })),
+      if (distinctValues.size > 1) {
+        // Multiple distinct declared values — cannot pick one without guessing.
+        const components = [...new Set(matches.map((m) => m.component))]
+        const scope = components.length === 1
+          ? `declared ${matches.length} times within "${components[0]}"`
+          : `declared with different values across ${components.length} components`
+        return {
+          name, value: null, resolvedVia: [],
+          ambiguous: matches.map(({ component, value }) => ({ component, value })),
+          note: `${scope} — likely responsive/theme variants this dataset flattens. ` +
+            `Use tokens_list_component_vars for a specific component, or check BSI docs for context.`,
+        }
       }
-    }
-    if (matches.some((m) => m.type === 'scss-expression')) {
-      return {
-        name, value: null, resolvedVia: [],
-        note: 'scss-expression value(s) found — cannot resolve to a concrete value (requires SCSS compilation context)',
+
+      // Single distinct value declared everywhere — safe to resolve directly.
+      const single = matches[0]
+      if (single.type === 'literal') {
+        return { name, value: single.value, resolvedVia: [] }
       }
-    }
-    if (matches.some((m) => m.type === 'token-reference')) {
-      return {
-        name, value: null, resolvedVia: [],
-        note: 'found as a token-reference but its chain could not be resolved',
+      if (single.type === 'scss-expression') {
+        return {
+          name, value: null, resolvedVia: [],
+          note: 'scss-expression value(s) found — cannot resolve to a concrete value (requires SCSS compilation context)',
+        }
       }
+      // type === 'token-reference' and unambiguous — fall through to the
+      // normal chain resolution below, which follows this single reference.
     }
   }
 
-  return { name, value: null, resolvedVia: chain }
+  const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
+  return { name, value, resolvedVia: chain }
 }
 
 // ─── Inverse lookup (tokens_find_components) ──────────────────────────────────
@@ -362,15 +372,16 @@ export async function findComponentsByToken(input: string): Promise<Array<{
       const ref = e.value.match(/^var\((--[a-z0-9-]+)\)/)?.[1]
       if (!ref) {
         // var(--x, fallback) or other unmatched form — still report on
-        // direct match so the token doesn't silently vanish from results.
+        // direct match so the token doesn't silently vanish from results,
+        // but don't claim an unresolved raw string as a resolved value.
         if (isDirectMatch) {
-          results.push({ component, token: name, resolvedVia: [], valueResolved: e.value })
+          results.push({ component, token: name, resolvedVia: [], valueResolved: null })
         }
         continue
       }
 
       const { value, chain } = resolveChain(ref, bsiMap, bridge, dtiRaw)
-      const fullChain = [hopFor(ref, bridge), ...chain]
+      const fullChain = [hopFor(ref, dtiRaw, bridge), ...chain]
 
       if (isDirectMatch || fullChain.some((h) => h.name === target)) {
         results.push({ component, token: name, resolvedVia: fullChain, valueResolved: value })

--- a/src/loaders/tokens.ts
+++ b/src/loaders/tokens.ts
@@ -1,8 +1,8 @@
 import { fetchText, fetchJson } from '../fetch.js'
 import { cache, CACHE_KEYS, TTL } from '../cache.js'
-import type { CssToken } from '../types.js'
 import { loadAllTokens, classifyValue } from './bsi.js'
-import { SNAPSHOT_DTI_VARIABLES_SCSS_URL, SNAPSHOT_BSI_ROOT_SCSS_URL, SNAPSHOT_BSI_CUSTOM_PROPERTIES_URL, } from '../constants.js'
+import type { CssToken, ResolvedHop, TokenRole } from '../types.js'
+import { SNAPSHOT_DTI_VARIABLES_SCSS_URL, SNAPSHOT_BSI_ROOT_SCSS_URL, SNAPSHOT_BSI_CUSTOM_PROPERTIES_URL } from '../constants.js'
 
 // Map 1: --bsi-* component tokens (custom-properties.json) — token-reference entries only
 // Map 2: --bsi-* → --it-* bridge (BSI _root.scss v3 — Sass compile-time via #{tokens.$it-*})
@@ -11,13 +11,16 @@ import { SNAPSHOT_DTI_VARIABLES_SCSS_URL, SNAPSHOT_BSI_ROOT_SCSS_URL, SNAPSHOT_B
 // Resolution chain: --bsi-accordion-padding → --bsi-spacing-m → --it-spacing-m → --it-spacing-6x → 24px
 
 // ─── Parsers ──────────────────────────────────────────────────────────────────
+// Exported so canary.config.ts validates the live chain with the exact same
+// parsing logic the server uses, instead of a duplicated regex that can drift
+// out of sync (this drift is what caused the v0.3.12 root.scss bug).
 
 type DtiMap = Map<string, string>     // --it-* → value or --it-* reference
 type BridgeMap = Map<string, string>  // --bsi-* → --it-* (root.scss)
 type BsiMap = Map<string, string>     // --bsi-* → --bsi-* or --it-* (custom-properties.json, token-reference only)
 
 // Format: $it-spacing-m: 1.5rem; // 24px
-function parseDesignTokens(scss: string): DtiMap {
+export function parseDesignTokens(scss: string): DtiMap {
   const map: DtiMap = new Map()
   for (const line of scss.split('\n')) {
     const match = line.match(/^\$([a-z0-9-]+):\s*([^;]+);(?:\s*\/\/\s*(.+))?/)
@@ -35,7 +38,7 @@ function parseDesignTokens(scss: string): DtiMap {
 }
 
 // Format: --#{$prefix}spacing-m: #{tokens.$it-spacing-m};
-function parseBridge(scss: string): BridgeMap {
+export function parseBridge(scss: string): BridgeMap {
   const map: BridgeMap = new Map()
   for (const line of scss.split('\n')) {
     const match = line.match(/--#\{\$prefix\}([a-z0-9-]+):\s*#\{tokens\.\$it-([a-z0-9-]+)\}/)
@@ -47,7 +50,8 @@ function parseBridge(scss: string): BridgeMap {
 }
 
 // Extract --bsi-* → var(--bsi-* | --it-*) from custom-properties.json
-// Only token-reference entries — literals are already concrete
+// Only token-reference entries — literals are already concrete (see
+// resolveToken()'s literal fallback for those).
 type RawTokensJson = Record<string, Array<{ 'variable-name': string; value: string }>>
 
 function parseBsiMap(raw: RawTokensJson): BsiMap {
@@ -62,14 +66,32 @@ function parseBsiMap(raw: RawTokensJson): BsiMap {
   return map
 }
 
+// ─── Manipulability role ────────────────────────────────────────────────────
+// A node's role is intrinsic to what it is, not to how it was reached:
+// a --bsi-* name that's a key in the global bridge is "bsi-global"
+// (root.scss level, e.g. --bsi-spacing-m); any other --bsi-* is
+// "bsi-component" (per-component custom-properties.json entry); anything
+// --it-* is "dti" (central Design Token, not overridable per-project).
+
+function roleFor(name: string, bridge: BridgeMap): TokenRole {
+  if (name.startsWith('--it-')) return 'dti'
+  if (bridge.has(name)) return 'bsi-global'
+  return 'bsi-component'
+}
+
+function hopFor(name: string, bridge: BridgeMap): ResolvedHop {
+  return { name, role: roleFor(name, bridge), overridable: !name.startsWith('--it-') }
+}
+
 // ─── Unified resolver ─────────────────────────────────────────────────────────
 //
 // Follows the full chain: --bsi-* → --bsi-* → --it-* → --it-* → concrete value
-// Returns { value, chain } where chain is every intermediate hop (excluding start and final value)
+// Returns { value, chain } where chain is every intermediate hop (excluding
+// the starting name), each labeled with its manipulability role.
 
 interface ResolveResult {
   value: string | null
-  chain: string[]
+  chain: ResolvedHop[]
 }
 
 function resolveChain(
@@ -87,7 +109,7 @@ function resolveChain(
     const next = bsiMap.get(name) ?? bridge.get(name)
     if (!next) return { value: null, chain: [] }
     const result = resolveChain(next, bsiMap, bridge, dtiRaw, visited)
-    return { value: result.value, chain: [next, ...result.chain] }
+    return { value: result.value, chain: [hopFor(next, bridge), ...result.chain] }
   }
 
   // --it-* → follow dtiRaw
@@ -96,7 +118,7 @@ function resolveChain(
     if (!val) return { value: null, chain: [] }
     if (val.startsWith('--it-')) {
       const result = resolveChain(val, bsiMap, bridge, dtiRaw, visited)
-      return { value: result.value, chain: [val, ...result.chain] }
+      return { value: result.value, chain: [hopFor(val, bridge), ...result.chain] }
     }
     return { value: val, chain: [] }
   }
@@ -163,11 +185,10 @@ export async function resolveTokenValues(tokens: CssToken[]): Promise<CssToken[]
     // re-lookup of token.name in bsiMap. custom_properties.json can contain
     // duplicate variable-names across components with different values —
     // bsiMap is a flat Map keyed by name, so a re-lookup by name can return
-    // a different component's value (last write wins). Starting from `ref`,
-    // read directly from this token's own value field, sidesteps that
-    // ambiguity entirely.
+    // a different component's value (last write wins). Starting from `ref`
+    // sidesteps that ambiguity entirely.
     const { value, chain } = resolveChain(ref, maps.bsiMap, maps.bridge, maps.dtiRaw)
-    return { ...token, valueResolved: value, resolvedVia: [ref, ...chain] }
+    return { ...token, valueResolved: value, resolvedVia: [hopFor(ref, maps.bridge), ...chain] }
   })
 }
 
@@ -175,10 +196,10 @@ export async function resolveTokenValues(tokens: CssToken[]): Promise<CssToken[]
 
 export async function searchDesignTokens(
   query: string
-): Promise<Array<{ name: string; value: string; resolvedVia: string[] }>> {
+): Promise<Array<{ name: string; value: string; resolvedVia: ResolvedHop[] }>> {
   const { bsiMap, bridge, dtiRaw } = await loadMaps()
   const q = query.toLowerCase()
-  const results: Array<{ name: string; value: string; resolvedVia: string[] }> = []
+  const results: Array<{ name: string; value: string; resolvedVia: ResolvedHop[] }> = []
 
   for (const [name] of dtiRaw) {
     const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
@@ -199,45 +220,78 @@ export async function searchDesignTokens(
 // so $it-* just needs converting before the first lookup.
 
 function normalizeTokenName(input: string): string {
-  if (input.startsWith('$it-')) return `--it-${input.slice(4)}`
-  if (input.startsWith('--bsi-') || input.startsWith('--it-')) return input
+  const trimmed = input.trim()
+  if (trimmed.startsWith('$')) return `--${trimmed.slice(1)}`
+  if (trimmed.startsWith('--bsi-') || trimmed.startsWith('--it-')) return trimmed
   // Defensive: bare name without -- prefix (e.g. "it-spacing-m", "bsi-accordion-padding")
-  if (input.startsWith('it-') || input.startsWith('bsi-')) return `--${input}`
-  return input
-}
-
-// ─── Single token resolution (tokens_resolve) ─────────────────────────────────
-
-export async function resolveToken(input: string): Promise<{
-  name: string
-  value: string | null
-  resolvedVia: string[]
-}> {
-  const name = normalizeTokenName(input)
-  const { bsiMap, bridge, dtiRaw } = await loadMaps()
-  const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
-  return { name, value, resolvedVia: chain }
+  if (trimmed.startsWith('it-') || trimmed.startsWith('bsi-')) return `--${trimmed}`
+  return trimmed
 }
 
 // ─── Global bridge-pair listing (tokens_list_globals) ─────────────────────────
 // Iterates the --bsi-* -> --it-* map parsed live from BSI's root.scss — grows
 // automatically as BSI adds bridge entries. Never a hardcoded list, never a
-// null or non-bridged row (see memory: count canaries are noise, this isn't one).
+// null or non-bridged row.
 
 export async function listGlobalBridgePairs(): Promise<Array<{
   it: string
   bsiGlobal: string
   value: string | null
-  resolvedVia: string[]
+  resolvedVia: ResolvedHop[]
 }>> {
   const { bsiMap, bridge, dtiRaw } = await loadMaps()
-  const results: Array<{ it: string; bsiGlobal: string; value: string | null; resolvedVia: string[] }> = []
+  const results: Array<{ it: string; bsiGlobal: string; value: string | null; resolvedVia: ResolvedHop[] }> = []
 
   for (const [bsiGlobal, it] of bridge) {
     const { value, chain } = resolveChain(it, bsiMap, bridge, dtiRaw)
     results.push({ it, bsiGlobal, value, resolvedVia: chain })
   }
   return results
+}
+
+// ─── Single token resolution (tokens_resolve) ─────────────────────────────────
+
+export interface ResolveTokenResult {
+  name: string
+  value: string | null
+  resolvedVia: ResolvedHop[]
+  // Present only when the input is a literal --bsi-* value that differs
+  // across components — cannot pick one without guessing which component
+  // the caller means. Surfaced instead of an arbitrary answer.
+  ambiguous?: Array<{ component: string; value: string }>
+}
+
+export async function resolveToken(input: string): Promise<ResolveTokenResult> {
+  const name = normalizeTokenName(input)
+  const { bsiMap, bridge, dtiRaw } = await loadMaps()
+  const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
+
+  if (value !== null) {
+    return { name, value, resolvedVia: chain }
+  }
+
+  // Fallback: name may be a literal --bsi-* value (e.g. "0", "1px"), which
+  // parseBsiMap never indexes because it only captures token-reference
+  // entries. Search the raw per-component data directly instead of
+  // declaring a token that genuinely exists "not found".
+  if (name.startsWith('--bsi-')) {
+    const allTokens = await loadAllTokens()
+    const matches: Array<{ component: string; value: string }> = []
+    for (const [component, entries] of Object.entries(allTokens)) {
+      for (const e of entries) {
+        if (e['variable-name'] === name) matches.push({ component, value: e.value })
+      }
+    }
+    const distinctValues = new Set(matches.map((m) => m.value))
+    if (distinctValues.size === 1) {
+      return { name, value: matches[0].value, resolvedVia: [] }
+    }
+    if (distinctValues.size > 1) {
+      return { name, value: null, resolvedVia: [], ambiguous: matches }
+    }
+  }
+
+  return { name, value: null, resolvedVia: chain }
 }
 
 // ─── Inverse lookup (tokens_find_components) ──────────────────────────────────
@@ -248,66 +302,38 @@ export async function listGlobalBridgePairs(): Promise<Array<{
 export async function findComponentsByToken(input: string): Promise<Array<{
   component: string
   token: string
-  resolvedVia: string[]
+  resolvedVia: ResolvedHop[]
   valueResolved: string | null
 }>> {
   const target = normalizeTokenName(input)
   const [allTokens, maps] = await Promise.all([loadAllTokens(), loadMaps()])
   const { bsiMap, bridge, dtiRaw } = maps
-  const results: Array<{ component: string; token: string; resolvedVia: string[]; valueResolved: string | null }> = []
+  const results: Array<{ component: string; token: string; resolvedVia: ResolvedHop[]; valueResolved: string | null }> = []
 
   for (const [component, entries] of Object.entries(allTokens)) {
     for (const e of entries) {
       const name = e['variable-name']
+      const isDirectMatch = name === target
 
-      if (name === target) {
-        results.push({ component, token: name, resolvedVia: [], valueResolved: e.value })
+      if (classifyValue(e.value) !== 'token-reference') {
+        // Literal token — no chain possible. Include only on direct match,
+        // with its raw value (nothing to resolve further).
+        if (isDirectMatch) {
+          results.push({ component, token: name, resolvedVia: [], valueResolved: e.value })
+        }
         continue
       }
 
-      if (classifyValue(e.value) !== 'token-reference') continue
+      const ref = e.value.match(/^var\((--[a-z0-9-]+)\)/)?.[1]
+      if (!ref) continue
 
-      const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
-      if (chain.includes(target)) {
-        results.push({ component, token: name, resolvedVia: chain, valueResolved: value })
+      const { value, chain } = resolveChain(ref, bsiMap, bridge, dtiRaw)
+      const fullChain = [hopFor(ref, bridge), ...chain]
+
+      if (isDirectMatch || fullChain.some((h) => h.name === target)) {
+        results.push({ component, token: name, resolvedVia: fullChain, valueResolved: value })
       }
     }
   }
   return results
 }
-
-// Debug: uncomment to diagnose token resolution chain (bridge/DTI sizes, key matching)
-// export async function debugTokenResolution(): Promise<string[]> {
-//   const logs: string[] = []
-
-//   try {
-//     const [rootScss, variablesScss] = await Promise.all([
-//       fetchText(BSI_ROOT_SCSS_URL),
-//       fetchText(DTI_VARIABLES_SCSS_URL),
-//     ])
-
-//     const bridge = parseBridge(rootScss)
-//     const dtiRaw = parseDesignTokens(variablesScss)
-
-//     logs.push(`bridge.size: ${bridge.size}`)
-//     logs.push(`dtiRaw.size: ${dtiRaw.size}`)
-
-//     // Count concrete vs reference values in DTI
-//     let concrete = 0, refs = 0
-//     for (const val of dtiRaw.values()) {
-//       if (val.startsWith('--it-')) refs++
-//       else concrete++
-//     }
-//     logs.push(`dtiRaw: ${concrete} concrete, ${refs} references`)
-
-//     // Sample bridge entries and check if DTI has them
-//     const sample = [...bridge.entries()].slice(0, 3)
-//     for (const [bsi, it] of sample) {
-//       logs.push(`${bsi} → ${it} → dtiRaw.has: ${dtiRaw.has(it)}`)
-//     }
-//   } catch (err) {
-//     logs.push(`error: ${(err as Error).message}`)
-//   }
-
-//   return logs
-// }

--- a/src/loaders/tokens.ts
+++ b/src/loaders/tokens.ts
@@ -80,7 +80,14 @@ function roleFor(name: string, bridge: BridgeMap): TokenRole {
 }
 
 function hopFor(name: string, bridge: BridgeMap): ResolvedHop {
-  return { name, role: roleFor(name, bridge), overridable: !name.startsWith('--it-') }
+  const role = roleFor(name, bridge)
+  return {
+    name,
+    sourceName: role === 'dti' ? `$${name.slice(2)}` : name,
+    form: role === 'dti' ? 'sass-variable' : 'css-custom-property',
+    role,
+    overridable: role !== 'dti',
+  }
 }
 
 // ─── Unified resolver ─────────────────────────────────────────────────────────
@@ -221,6 +228,10 @@ export async function searchDesignTokens(
 
 function normalizeTokenName(input: string): string {
   const trimmed = input.trim()
+  // var(--bsi-accordion-padding) — the exact value field the model just read
+  // from tokens_list_component_vars, likely the single most common input.
+  const varMatch = trimmed.match(/^var\((--[a-z0-9-]+)\)/)
+  if (varMatch) return varMatch[1]
   if (trimmed.startsWith('$')) return `--${trimmed.slice(1)}`
   if (trimmed.startsWith('--bsi-') || trimmed.startsWith('--it-')) return trimmed
   // Defensive: bare name without -- prefix (e.g. "it-spacing-m", "bsi-accordion-padding")
@@ -259,6 +270,10 @@ export interface ResolveTokenResult {
   // across components — cannot pick one without guessing which component
   // the caller means. Surfaced instead of an arbitrary answer.
   ambiguous?: Array<{ component: string; value: string }>
+  // Present when value is null but the token exists with a value that
+  // genuinely can't be resolved (scss-expression, or a broken chain) —
+  // distinguishes "found but unresolvable" from "not found at all".
+  note?: string
 }
 
 export async function resolveToken(input: string): Promise<ResolveTokenResult> {
@@ -276,18 +291,38 @@ export async function resolveToken(input: string): Promise<ResolveTokenResult> {
   // declaring a token that genuinely exists "not found".
   if (name.startsWith('--bsi-')) {
     const allTokens = await loadAllTokens()
-    const matches: Array<{ component: string; value: string }> = []
+    const matches: Array<{ component: string; value: string; type: ReturnType<typeof classifyValue> }> = []
     for (const [component, entries] of Object.entries(allTokens)) {
       for (const e of entries) {
-        if (e['variable-name'] === name) matches.push({ component, value: e.value })
+        if (e['variable-name'] === name) {
+          matches.push({ component, value: e.value, type: classifyValue(e.value) })
+        }
       }
     }
-    const distinctValues = new Set(matches.map((m) => m.value))
-    if (distinctValues.size === 1) {
-      return { name, value: matches[0].value, resolvedVia: [] }
+
+    const literals = matches.filter((m) => m.type === 'literal')
+    const distinctLiteralValues = new Set(literals.map((m) => m.value))
+
+    if (distinctLiteralValues.size === 1 && matches.length === literals.length) {
+      return { name, value: literals[0].value, resolvedVia: [] }
     }
-    if (distinctValues.size > 1) {
-      return { name, value: null, resolvedVia: [], ambiguous: matches }
+    if (distinctLiteralValues.size > 1) {
+      return {
+        name, value: null, resolvedVia: [],
+        ambiguous: matches.map(({ component, value }) => ({ component, value })),
+      }
+    }
+    if (matches.some((m) => m.type === 'scss-expression')) {
+      return {
+        name, value: null, resolvedVia: [],
+        note: 'scss-expression value(s) found — cannot resolve to a concrete value (requires SCSS compilation context)',
+      }
+    }
+    if (matches.some((m) => m.type === 'token-reference')) {
+      return {
+        name, value: null, resolvedVia: [],
+        note: 'found as a token-reference but its chain could not be resolved',
+      }
     }
   }
 
@@ -325,7 +360,14 @@ export async function findComponentsByToken(input: string): Promise<Array<{
       }
 
       const ref = e.value.match(/^var\((--[a-z0-9-]+)\)/)?.[1]
-      if (!ref) continue
+      if (!ref) {
+        // var(--x, fallback) or other unmatched form — still report on
+        // direct match so the token doesn't silently vanish from results.
+        if (isDirectMatch) {
+          results.push({ component, token: name, resolvedVia: [], valueResolved: e.value })
+        }
+        continue
+      }
 
       const { value, chain } = resolveChain(ref, bsiMap, bridge, dtiRaw)
       const fullChain = [hopFor(ref, bridge), ...chain]

--- a/src/loaders/tokens.ts
+++ b/src/loaders/tokens.ts
@@ -1,6 +1,7 @@
 import { fetchText, fetchJson } from '../fetch.js'
 import { cache, CACHE_KEYS, TTL } from '../cache.js'
 import type { CssToken } from '../types.js'
+import { loadAllTokens, classifyValue } from './bsi.js'
 import { SNAPSHOT_DTI_VARIABLES_SCSS_URL, SNAPSHOT_BSI_ROOT_SCSS_URL, SNAPSHOT_BSI_CUSTOM_PROPERTIES_URL, } from '../constants.js'
 
 // Map 1: --bsi-* component tokens (custom-properties.json) — token-reference entries only
@@ -187,6 +188,91 @@ export async function searchDesignTokens(
     }
   }
 
+  return results
+}
+
+// ─── Multi-form token name normalization ──────────────────────────────────────
+// tokens_resolve and tokens_find_components accept any point in the chain:
+// --bsi-*, --it-*, or the Sass source form $it-* (as written in
+// design-tokens-italia/_variables.scss, before compilation to a CSS custom
+// property). Everything downstream (bridge, dtiRaw) already keys on --it-*,
+// so $it-* just needs converting before the first lookup.
+
+function normalizeTokenName(input: string): string {
+  if (input.startsWith('$it-')) return `--it-${input.slice(4)}`
+  if (input.startsWith('--bsi-') || input.startsWith('--it-')) return input
+  // Defensive: bare name without -- prefix (e.g. "it-spacing-m", "bsi-accordion-padding")
+  if (input.startsWith('it-') || input.startsWith('bsi-')) return `--${input}`
+  return input
+}
+
+// ─── Single token resolution (tokens_resolve) ─────────────────────────────────
+
+export async function resolveToken(input: string): Promise<{
+  name: string
+  value: string | null
+  resolvedVia: string[]
+}> {
+  const name = normalizeTokenName(input)
+  const { bsiMap, bridge, dtiRaw } = await loadMaps()
+  const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
+  return { name, value, resolvedVia: chain }
+}
+
+// ─── Global bridge-pair listing (tokens_list_globals) ─────────────────────────
+// Iterates the --bsi-* -> --it-* map parsed live from BSI's root.scss — grows
+// automatically as BSI adds bridge entries. Never a hardcoded list, never a
+// null or non-bridged row (see memory: count canaries are noise, this isn't one).
+
+export async function listGlobalBridgePairs(): Promise<Array<{
+  it: string
+  bsiGlobal: string
+  value: string | null
+  resolvedVia: string[]
+}>> {
+  const { bsiMap, bridge, dtiRaw } = await loadMaps()
+  const results: Array<{ it: string; bsiGlobal: string; value: string | null; resolvedVia: string[] }> = []
+
+  for (const [bsiGlobal, it] of bridge) {
+    const { value, chain } = resolveChain(it, bsiMap, bridge, dtiRaw)
+    results.push({ it, bsiGlobal, value, resolvedVia: chain })
+  }
+  return results
+}
+
+// ─── Inverse lookup (tokens_find_components) ──────────────────────────────────
+// Given a token name, finds every BSI component whose token resolves through
+// it — either directly (the token itself) or as an intermediate hop in the
+// --bsi-* -> --it-* chain.
+
+export async function findComponentsByToken(input: string): Promise<Array<{
+  component: string
+  token: string
+  resolvedVia: string[]
+  valueResolved: string | null
+}>> {
+  const target = normalizeTokenName(input)
+  const [allTokens, maps] = await Promise.all([loadAllTokens(), loadMaps()])
+  const { bsiMap, bridge, dtiRaw } = maps
+  const results: Array<{ component: string; token: string; resolvedVia: string[]; valueResolved: string | null }> = []
+
+  for (const [component, entries] of Object.entries(allTokens)) {
+    for (const e of entries) {
+      const name = e['variable-name']
+
+      if (name === target) {
+        results.push({ component, token: name, resolvedVia: [], valueResolved: e.value })
+        continue
+      }
+
+      if (classifyValue(e.value) !== 'token-reference') continue
+
+      const { value, chain } = resolveChain(name, bsiMap, bridge, dtiRaw)
+      if (chain.includes(target)) {
+        results.push({ component, token: name, resolvedVia: chain, valueResolved: value })
+      }
+    }
+  }
   return results
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -19,6 +19,8 @@ export const ZMeta = z.object({
 
 const ZResolvedHop = z.object({
   name: z.string(),
+  sourceName: z.string(),
+  form: z.enum(['css-custom-property', 'sass-variable']),
   role: z.enum(['bsi-component', 'bsi-global', 'dti']),
   overridable: z.boolean(),
 })

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,12 +17,18 @@ export const ZMeta = z.object({
   versions: ZVersions.optional(),
 })
 
+const ZResolvedHop = z.object({
+  name: z.string(),
+  role: z.enum(['bsi-component', 'bsi-global', 'dti']),
+  overridable: z.boolean(),
+})
+
 export const ZCssToken = z.object({
   name: z.string(),
   value: z.string(),
   valueType: z.enum(['token-reference', 'scss-expression', 'literal']),
   valueResolved: z.string().nullable(),
-  resolvedVia: z.array(z.string()),
+  resolvedVia: z.array(ZResolvedHop),
   description: z.string().nullable(),
   valueResolvedNote: z.string().optional(),
 })

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -29,7 +29,7 @@ export const ZCssToken = z.object({
 
 // ─── get_component_tokens ─────────────────────────────────────────────────────
 
-export const ZGetComponentTokensOutput = z.object({
+export const ZTokensListComponentVarsOutput = z.object({
   component: z.string(),
   total: z.number(),
   tokens: z.array(ZCssToken),

--- a/src/tools/helpers.test.ts
+++ b/src/tools/helpers.test.ts
@@ -83,6 +83,20 @@ describe('unionRows — identity by entry.id', () => {
     const devkitRows = rows.filter((r) => r.devkit !== null)
     assert.equal(devkitRows.length, devKit.size)
   })
+
+  it('exact slug match wins over an alias match, regardless of iteration order', () => {
+    // Dev Kit has "button" (exact match for BSI "button") but BSI also
+    // has "buttons", which aliases to "button" too. "button" must win.
+    const statuses = new Map([
+      ['buttons', status('buttons', 'Buttons')],
+      ['button', status('button', 'Button')],
+    ])
+    const devKit = new Map([['button', devKitEntry({ slug: 'button', id: 'componenti-button--documentazione' })]])
+    const rows = unionRows(statuses, devKit)
+    const withDevkit = rows.filter((r) => r.devkit !== null)
+    assert.equal(withDevkit.length, 1)
+    assert.equal(withDevkit[0].slug, 'button')   // exact match, not the alias "buttons"
+  })
 })
 
 // ─── DevKit-only rows ───────────────────────────────────────────────────────

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -90,18 +90,39 @@ export function unionRows(
   devKitIndex: Map<string, DevKitEntry>
 ): UnionRow[] {
   const claimedEntries = new Set<string>()   // key: dk.id — Storybook's guaranteed-unique identifier
-  const rows: UnionRow[] = []
+  const matches = new Map<string, DevKitEntry | null>()   // bsiSlug -> matched entry (or null)
 
-  // Pass 1: every BSI slug, cross-matched to its Dev Kit counterpart via slugsToTry.
-  for (const [bsiSlug, s] of statuses) {
-    const devKitSlug = slugsToTry(bsiSlug).find((a) => devKitIndex.has(a)) ?? null
+  // Pass 1a: exact slug matches first. These must win over alias matches
+  // regardless of Map iteration order — otherwise which BSI slug claims a
+  // shared Dev Kit entry would depend on source ordering, not semantics.
+  for (const bsiSlug of statuses.keys()) {
+    const dk = devKitIndex.get(bsiSlug) ?? null
+    if (dk && !claimedEntries.has(dk.id)) {
+      claimedEntries.add(dk.id)
+      matches.set(bsiSlug, dk)
+    }
+  }
+
+  // Pass 1b: alias matches (via slugsToTry) for whatever wasn't claimed by
+  // an exact match above.
+  for (const bsiSlug of statuses.keys()) {
+    if (matches.has(bsiSlug)) continue
+    const devKitSlug = slugsToTry(bsiSlug).find((a) => {
+      const dk = devKitIndex.get(a)
+      return dk && !claimedEntries.has(dk.id)
+    })
     const dk = devKitSlug ? devKitIndex.get(devKitSlug)! : null
     // If this Dev Kit entry was already claimed by an earlier BSI slug (two
-    // BSI slugs aliasing to the same Dev Kit entry), this row gets bsi-only:
-    // the devkit block stays attached to whichever BSI row claimed it first.
-    const alreadyClaimed = dk ? claimedEntries.has(dk.id) : false
-    if (dk && !alreadyClaimed) claimedEntries.add(dk.id)
+    // BSI slugs aliasing to the same Dev Kit entry), dk is null here — this
+    // row gets bsi-only: the devkit block stays attached to whichever BSI
+    // row claimed it first (in exact-match or alias order).
+    if (dk) claimedEntries.add(dk.id)
+    matches.set(bsiSlug, dk)
+  }
 
+  const rows: UnionRow[] = []
+  for (const [bsiSlug, s] of statuses) {
+    const dk = matches.get(bsiSlug) ?? null
     rows.push({
       name: s.name,
       slug: bsiSlug,
@@ -113,16 +134,16 @@ export function unionRows(
         accessibility: { checkCompleted: s.accessibility.checkCompleted },
         docUrl: s.sourceUrls.bsiDoc ?? bsiDocUrl(bsiSlug),
       },
-      devkit: dk && !alreadyClaimed
+      devkit: dk
         ? { slug: dk.slug, tags: dk.tags, storybookUrl: dk.storybookUrl, pattern: dk.pattern, componentType: dk.componentType }
         : null,
     })
   }
 
-  // Pass 2: Dev Kit-only entries — no BSI counterpart claimed this id in pass 1.
-  // Identity is the Storybook entry id, not the slug string: two different
-  // entries whose slugs happen to alias to each other (e.g. a genuine "tag"
-  // entry aliasing to "chips") must never collapse into one.
+  // Pass 2: Dev Kit-only entries — no BSI counterpart claimed this id in
+  // pass 1a/1b. Identity is the Storybook entry id, not the slug string:
+  // two different entries whose slugs happen to alias to each other (e.g.
+  // a genuine "tag" entry aliasing to "chips") must never collapse into one.
   for (const [, dk] of devKitIndex) {
     if (claimedEntries.has(dk.id)) continue
     rows.push({

--- a/src/tools/tokens-find-components.ts
+++ b/src/tools/tokens-find-components.ts
@@ -12,27 +12,27 @@ export function registerTokensFindComponents(server: McpServer): void {
     'tokens_find_components',
     {
       title: 'Find Components By Token',
-      description: 'Finds all Bootstrap Italia components whose CSS custom properties resolve ' +
-        'through a given token, directly or via the --bsi-* → --it-* chain. ' +
-        'Accepts --bsi-*, --it-*, or the Sass source form $it-*. ' +
-        'Example: "--it-spacing-m" → every --bsi-*-spacing-m across all components.',
-      inputSchema: { name: z.string().describe('Token name in any form: --bsi-*, --it-*, or $it-*') },
+      description: 'Returns the Bootstrap Italia components impacted by a given design variable, ' +
+        'including indirect impact via the resolution chain. Accepts --bsi-* (direct usage) or ' +
+        '--it-*/$it-* (impact traced through the chain). Useful for theming: identifies what changes ' +
+        'if you override a variable.',
+      inputSchema: { variable: z.string().describe('Token name in any form: --bsi-*, --it-*, or $it-*') },
       annotations: { readOnlyHint: true },
     },
-    async ({ name }) => {
-      name = name.trim()
+    async ({ variable }) => {
+      variable = variable.trim()
       const warnings: string[] = [ALPHA_WARNING]
       const [results, dsMeta] = await Promise.all([
-        findComponentsByToken(name),
+        findComponentsByToken(variable),
         loadDsMeta(),
       ])
 
       if (results.length === 0) {
-        warnings.push(`No components found referencing "${name}"`)
+        warnings.push(`No components found referencing "${variable}"`)
       }
 
       const output = {
-        query: name,
+        query: variable,
         total: results.length,
         results,
         meta: buildMeta({

--- a/src/tools/tokens-find-components.ts
+++ b/src/tools/tokens-find-components.ts
@@ -1,0 +1,52 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { findComponentsByToken } from '../loaders/tokens.js'
+import { loadDsMeta } from '../loaders/meta.js'
+import { buildMeta } from './helpers.js'
+import { ALPHA_WARNING, BSI_CUSTOM_PROPERTIES_URL, BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL } from '../constants.js'
+
+// ─── Tool: tokens_find_components ─────────────────────────────────────────────
+
+export function registerTokensFindComponents(server: McpServer): void {
+  server.registerTool(
+    'tokens_find_components',
+    {
+      title: 'Find Components By Token',
+      description: 'Finds all Bootstrap Italia components whose CSS custom properties resolve ' +
+        'through a given token, directly or via the --bsi-* → --it-* chain. ' +
+        'Accepts --bsi-*, --it-*, or the Sass source form $it-*. ' +
+        'Example: "--it-spacing-m" → every --bsi-*-spacing-m across all components.',
+      inputSchema: { name: z.string().describe('Token name in any form: --bsi-*, --it-*, or $it-*') },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ name }) => {
+      name = name.trim()
+      const warnings: string[] = [ALPHA_WARNING]
+      const [results, dsMeta] = await Promise.all([
+        findComponentsByToken(name),
+        loadDsMeta(),
+      ])
+
+      if (results.length === 0) {
+        warnings.push(`No components found referencing "${name}"`)
+      }
+
+      const output = {
+        query: name,
+        total: results.length,
+        results,
+        meta: buildMeta({
+          dsMeta,
+          sourceUrls: [BSI_CUSTOM_PROPERTIES_URL, BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL],
+          warnings,
+          stability: 'alpha',
+          extra: { versions: dsMeta?.versions ?? undefined },
+        }),
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+      }
+    }
+  )
+}

--- a/src/tools/tokens-list-component-vars.ts
+++ b/src/tools/tokens-list-component-vars.ts
@@ -1,30 +1,30 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
-import { ZGetComponentTokensOutput } from '../schemas.js'
-import { loadStatus, loadTokens, searchTokens } from '../loaders/bsi.js'
-import { resolveTokenValues, searchDesignTokens } from '../loaders/tokens.js'
+import { ZTokensListComponentVarsOutput } from '../schemas.js'
+import { loadStatus, loadTokens } from '../loaders/bsi.js'
+import { resolveTokenValues } from '../loaders/tokens.js'
 import { slugify } from '../slugify.js'
 import { loadDsMeta } from '../loaders/meta.js'
 import { buildMeta } from './helpers.js'
 import { ALPHA_WARNING, BSI_CUSTOM_PROPERTIES_URL, DTI_VARIABLES_SCSS_URL, BSI_ROOT_SCSS_URL } from '../constants.js'
 
-// ─── Tool: get_component_tokens ───────────────────────────────────────────────
+// ─── Tool: tokens_list_component_vars ─────────────────────────────────────────
 
-export function registerGetComponentTokens(server: McpServer): void {
+export function registerTokensListComponentVars(server: McpServer): void {
   server.registerTool(
-    'get_component_tokens',
+    'tokens_list_component_vars',
     {
-      title: 'Get Component Tokens',
+      title: 'List Component Tokens',
       description: 'Returns customizable CSS --bsi-* variables for a component, ' +
         'with semantic description and resolved value (e.g. var(--bsi-spacing-m) → 1.5rem). ' +
         'Useful to understand concrete values behind CSS custom properties or design tokens.',
-      inputSchema: { name: z.string().describe('Component name or slug (e.g. "accordion", "Alert")') },
+      inputSchema: { component: z.string().describe('Component name or slug (e.g. "accordion", "Alert")') },
       annotations: { readOnlyHint: true },
-      outputSchema: ZGetComponentTokensOutput,
+      outputSchema: ZTokensListComponentVarsOutput,
     },
-    async ({ name }) => {
-      name = name.trim()
-      const slug = slugify(name)
+    async ({ component }) => {
+      component = component.trim()
+      const slug = slugify(component)
       const warnings: string[] = []
 
       const [status, dsMeta] = await Promise.all([
@@ -33,7 +33,6 @@ export function registerGetComponentTokens(server: McpServer): void {
       ])
       const canonicalSlug = status?.slug ?? slug
 
-      // Load BSI tokens
       const rawTokens = await loadTokens(canonicalSlug)
 
       if (rawTokens.length === 0) {
@@ -42,28 +41,19 @@ export function registerGetComponentTokens(server: McpServer): void {
 
       warnings.push(ALPHA_WARNING)
 
-      // Resolve values via Design Tokens Italia
       let tokens = rawTokens
       try {
         tokens = await resolveTokenValues(rawTokens)
-        // Debug: uncomment to diagnose token resolution (see also debugTokenResolution in loaders/tokens.ts)
-        // const resolved = tokens.filter(t => t.valueResolved !== null).length
-        // const refs = tokens.filter(t => t.valueType === 'token-reference').length
-        // warnings.push(`[debug] ${refs} token-references, ${resolved} resolved`)
-        // const debugLogs = await debugTokenResolution()
-        // warnings.push(...debugLogs.map(l => `[debug] ${l}`))
       } catch {
         warnings.push('Design Tokens Italia value resolution not available')
       }
 
-      // Add valueResolvedNote for scss-expression tokens
       tokens = tokens.map(t =>
         t.valueType === 'scss-expression'
           ? { ...t, valueResolvedNote: 'scss-expression tokens cannot be resolved to a concrete value yet — value requires SCSS compilation context' }
           : t
       )
 
-      // // Group by type for readability
       const byType = {
         tokenReference: tokens.filter((t) => t.valueType === 'token-reference'),
         literal: tokens.filter((t) => t.valueType === 'literal'),

--- a/src/tools/tokens-list-globals.ts
+++ b/src/tools/tokens-list-globals.ts
@@ -1,0 +1,46 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { listGlobalBridgePairs } from '../loaders/tokens.js'
+import { loadDsMeta } from '../loaders/meta.js'
+import { buildMeta } from './helpers.js'
+import { ALPHA_WARNING, BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL } from '../constants.js'
+
+// ─── Tool: tokens_list_globals ─────────────────────────────────────────────────
+// Bridge-pair view: only components with a --bsi-* -> --it-* entry in root.scss
+// are included. List grows automatically as BSI adds bridge entries.
+
+export function registerTokensListGlobals(server: McpServer): void {
+  server.registerTool(
+    'tokens_list_globals',
+    {
+      title: 'List Global Tokens',
+      description: 'Lists global design tokens bridged between Bootstrap Italia (--bsi-*) and ' +
+        'Design Tokens Italia (--it-*), with resolved concrete values. ' +
+        'Only tokens with a bridge entry in root.scss are included.',
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    async () => {
+      const warnings: string[] = [ALPHA_WARNING]
+      const [pairs, dsMeta] = await Promise.all([
+        listGlobalBridgePairs(),
+        loadDsMeta(),
+      ])
+
+      const output = {
+        total: pairs.length,
+        tokens: pairs,
+        meta: buildMeta({
+          dsMeta,
+          sourceUrls: [BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL],
+          warnings,
+          stability: 'alpha',
+          extra: { versions: dsMeta?.versions ?? undefined },
+        }),
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+      }
+    }
+  )
+}

--- a/src/tools/tokens-list-globals.ts
+++ b/src/tools/tokens-list-globals.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
 import { listGlobalBridgePairs } from '../loaders/tokens.js'
 import { loadDsMeta } from '../loaders/meta.js'
 import { buildMeta } from './helpers.js'
@@ -13,22 +14,36 @@ export function registerTokensListGlobals(server: McpServer): void {
     'tokens_list_globals',
     {
       title: 'List Global Tokens',
-      description: 'Lists global design tokens bridged between Bootstrap Italia (--bsi-*) and ' +
-        'Design Tokens Italia (--it-*), with resolved concrete values. ' +
-        'Only tokens with a bridge entry in root.scss are included.',
-      inputSchema: {},
+      description: 'Lists the global design tokens of the Design System that Bootstrap Italia actually uses. ' +
+        'Each entry pairs the central Design Token (--it-*/$it-*, not overridable per-project) with the ' +
+        'corresponding global --bsi-* CSS custom property (project-overridable), plus its resolved value. ' +
+        'Without arguments returns all global tokens; pass category to filter (e.g. "spacing", "color"). ' +
+        'Only tokens bridged into BSI are listed. For per-component variables use tokens_list_component_vars.',
+      inputSchema: {
+        category: z.string().optional().describe('Filter by category keyword, e.g. "spacing", "color". Omit to list all.'),
+      },
       annotations: { readOnlyHint: true },
     },
-    async () => {
+    async ({ category }) => {
       const warnings: string[] = [ALPHA_WARNING]
       const [pairs, dsMeta] = await Promise.all([
         listGlobalBridgePairs(),
         loadDsMeta(),
       ])
 
+      const q = category?.trim().toLowerCase()
+      const filtered = q
+        ? pairs.filter((p) => p.it.toLowerCase().includes(q) || p.bsiGlobal.toLowerCase().includes(q))
+        : pairs
+
+      if (q && filtered.length === 0) {
+        warnings.push(`No global tokens found matching category "${category}"`)
+      }
+
       const output = {
-        total: pairs.length,
-        tokens: pairs,
+        category: category ?? null,
+        total: filtered.length,
+        tokens: filtered,
         meta: buildMeta({
           dsMeta,
           sourceUrls: [BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL],

--- a/src/tools/tokens-list-globals.ts
+++ b/src/tools/tokens-list-globals.ts
@@ -20,28 +20,28 @@ export function registerTokensListGlobals(server: McpServer): void {
         'Without arguments returns all global tokens; pass category to filter (e.g. "spacing", "color"). ' +
         'Only tokens bridged into BSI are listed. For per-component variables use tokens_list_component_vars.',
       inputSchema: {
-        category: z.string().optional().describe('Filter by category keyword, e.g. "spacing", "color". Omit to list all.'),
+        match: z.string().optional().describe('Substring filter on token/variable name (e.g. "spacing", "blue"). Not a semantic category — matches literal text in the name only. Omit to list all.'),
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ category }) => {
+    async ({ match }) => {
       const warnings: string[] = [ALPHA_WARNING]
       const [pairs, dsMeta] = await Promise.all([
         listGlobalBridgePairs(),
         loadDsMeta(),
       ])
 
-      const q = category?.trim().toLowerCase()
+      const q = match?.trim().toLowerCase()
       const filtered = q
         ? pairs.filter((p) => p.it.toLowerCase().includes(q) || p.bsiGlobal.toLowerCase().includes(q))
         : pairs
 
       if (q && filtered.length === 0) {
-        warnings.push(`No global tokens found matching category "${category}"`)
+        warnings.push(`No global tokens found matching "${match}"`)
       }
 
       const output = {
-        category: category ?? null,
+        match: match ?? null,
         total: filtered.length,
         tokens: filtered,
         meta: buildMeta({

--- a/src/tools/tokens-resolve.ts
+++ b/src/tools/tokens-resolve.ts
@@ -28,8 +28,15 @@ export function registerTokensResolve(server: McpServer): void {
       const dsMeta = await loadDsMeta()
 
       const result = await resolveToken(variable)
-      if (result.value === null) {
+      if (result.value === null && !result.ambiguous && !result.note) {
         warnings.push(`Could not resolve "${variable}" — not found in the --bsi-*/--it-* resolution chain`)
+      } else if (result.ambiguous) {
+        warnings.push(
+          `"${variable}" has different literal values across components — cannot resolve without a specific ` +
+          `component. Use tokens_list_component_vars for a specific component.`
+        )
+      } else if (result.note) {
+        warnings.push(result.note)
       }
 
       const output = {
@@ -37,6 +44,7 @@ export function registerTokensResolve(server: McpServer): void {
         normalizedName: result.name,
         value: result.value,
         resolvedVia: result.resolvedVia,
+        ...(result.ambiguous ? { ambiguousValues: result.ambiguous } : {}),
         meta: buildMeta({
           dsMeta,
           sourceUrls: [BSI_CUSTOM_PROPERTIES_URL, BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL],

--- a/src/tools/tokens-resolve.ts
+++ b/src/tools/tokens-resolve.ts
@@ -31,10 +31,7 @@ export function registerTokensResolve(server: McpServer): void {
       if (result.value === null && !result.ambiguous && !result.note) {
         warnings.push(`Could not resolve "${variable}" — not found in the --bsi-*/--it-* resolution chain`)
       } else if (result.ambiguous) {
-        warnings.push(
-          `"${variable}" has different literal values across components — cannot resolve without a specific ` +
-          `component. Use tokens_list_component_vars for a specific component.`
-        )
+        warnings.push(result.note ?? `"${variable}" has different values across occurrences.`)
       } else if (result.note) {
         warnings.push(result.note)
       }

--- a/src/tools/tokens-resolve.ts
+++ b/src/tools/tokens-resolve.ts
@@ -19,22 +19,22 @@ export function registerTokensResolve(server: McpServer): void {
         'following the full chain (--bsi-* → --it-* → value). ' +
         'Accepts --bsi-*, --it-*, or the Sass source form $it-*. ' +
         'Examples: "--bsi-accordion-padding", "--it-spacing-m", "$it-spacing-m".',
-      inputSchema: { name: z.string().describe('Token name in any form: --bsi-*, --it-*, or $it-*') },
+      inputSchema: { variable: z.string().describe('Token name in any form: --bsi-*, --it-*, or $it-*') },
       annotations: { readOnlyHint: true },
     },
-    async ({ name }) => {
-      name = name.trim()
+    async ({ variable }) => {
+      variable = variable.trim()
       const warnings: string[] = [ALPHA_WARNING]
       const dsMeta = await loadDsMeta()
 
-      const result = await resolveToken(name)
+      const result = await resolveToken(variable)
       if (result.value === null) {
-        warnings.push(`Could not resolve "${name}" — not found in the --bsi-*/--it-* resolution chain`)
+        warnings.push(`Could not resolve "${variable}" — not found in the --bsi-*/--it-* resolution chain`)
       }
 
       const output = {
-        input: name,
-        resolved: result.name,
+        input: variable,
+        normalizedName: result.name,
         value: result.value,
         resolvedVia: result.resolvedVia,
         meta: buildMeta({

--- a/src/tools/tokens-resolve.ts
+++ b/src/tools/tokens-resolve.ts
@@ -1,0 +1,54 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { resolveToken } from '../loaders/tokens.js'
+import { loadDsMeta } from '../loaders/meta.js'
+import { buildMeta } from './helpers.js'
+import { ALPHA_WARNING, BSI_CUSTOM_PROPERTIES_URL, BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL } from '../constants.js'
+
+// ─── Tool: tokens_resolve ──────────────────────────────────────────────────────
+// Accepts any point in the resolution chain: --bsi-*, --it-*, or the Sass
+// source form $it-* (as written in design-tokens-italia, before compilation
+// to a CSS custom property) — normalized internally before lookup.
+
+export function registerTokensResolve(server: McpServer): void {
+  server.registerTool(
+    'tokens_resolve',
+    {
+      title: 'Resolve Token',
+      description: 'Resolves a CSS custom property or design token to its concrete value, ' +
+        'following the full chain (--bsi-* → --it-* → value). ' +
+        'Accepts --bsi-*, --it-*, or the Sass source form $it-*. ' +
+        'Examples: "--bsi-accordion-padding", "--it-spacing-m", "$it-spacing-m".',
+      inputSchema: { name: z.string().describe('Token name in any form: --bsi-*, --it-*, or $it-*') },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ name }) => {
+      name = name.trim()
+      const warnings: string[] = [ALPHA_WARNING]
+      const dsMeta = await loadDsMeta()
+
+      const result = await resolveToken(name)
+      if (result.value === null) {
+        warnings.push(`Could not resolve "${name}" — not found in the --bsi-*/--it-* resolution chain`)
+      }
+
+      const output = {
+        input: name,
+        resolved: result.name,
+        value: result.value,
+        resolvedVia: result.resolvedVia,
+        meta: buildMeta({
+          dsMeta,
+          sourceUrls: [BSI_CUSTOM_PROPERTIES_URL, BSI_ROOT_SCSS_URL, DTI_VARIABLES_SCSS_URL],
+          warnings,
+          stability: 'alpha',
+          extra: { versions: dsMeta?.versions ?? undefined },
+        }),
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+      }
+    }
+  )
+}

--- a/src/tools/tokens-search.ts
+++ b/src/tools/tokens-search.ts
@@ -6,13 +6,13 @@ import { loadDsMeta } from '../loaders/meta.js'
 import { buildMeta } from './helpers.js'
 import { ALPHA_WARNING, BSI_CUSTOM_PROPERTIES_URL, DTI_VARIABLES_SCSS_URL } from '../constants.js'
 
-// ─── Tool: find_token ─────────────────────────────────────────────────────────
+// ─── Tool: tokens_search ───────────────────────────────────────────────────────
 
-export function registerFindToken(server: McpServer): void {
+export function registerTokensSearch(server: McpServer): void {
   server.registerTool(
-    'find_token',
+    'tokens_search',
     {
-      title: 'Find Token',
+      title: 'Search Tokens',
       description: 'Search for a Design Tokens Italia or BSI token by substring match on variable name. ' +
         'Searches all BSI components (--bsi-*) and global Design Tokens Italia tokens (--it-*). ' +
         'Examples: \'primary\', \'spacing-m\', \'blue-40\', \'radius\'. ' +
@@ -22,15 +22,11 @@ export function registerFindToken(server: McpServer): void {
     },
     async ({ query }) => {
       query = query.trim()
-      const warnings: string[] = []
+      const warnings: string[] = [ALPHA_WARNING]
       const dsMeta = await loadDsMeta()
 
-      warnings.push(ALPHA_WARNING)
-
-      // Search per-component BSI tokens
       const bsiResults = await searchTokens(query)
 
-      // Risolve values
       let resolvedBsi = bsiResults
       try {
         resolvedBsi = await resolveTokenValues(bsiResults) as typeof bsiResults
@@ -38,7 +34,6 @@ export function registerFindToken(server: McpServer): void {
         warnings.push('Design Tokens Italia value resolution not available')
       }
 
-      // Search global --it-* tokens
       let globalResults: Array<{ name: string; value: string }> = []
       try {
         globalResults = await searchDesignTokens(query)
@@ -46,34 +41,21 @@ export function registerFindToken(server: McpServer): void {
         warnings.push('Global Design Tokens Italia search not available')
       }
 
+      const output = {
+        query,
+        bsiTokens: { total: resolvedBsi.length, results: resolvedBsi },
+        globalTokens: { total: globalResults.length, results: globalResults },
+        meta: buildMeta({
+          dsMeta,
+          sourceUrls: [BSI_CUSTOM_PROPERTIES_URL, DTI_VARIABLES_SCSS_URL],
+          warnings,
+          stability: 'alpha',
+          extra: { versions: dsMeta?.versions ?? undefined },
+        }),
+      }
+
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(
-              {
-                query,
-                bsiTokens: {
-                  total: resolvedBsi.length,
-                  results: resolvedBsi,
-                },
-                globalTokens: {
-                  total: globalResults.length,
-                  results: globalResults,
-                },
-                meta: buildMeta({
-                  dsMeta,
-                  sourceUrls: [BSI_CUSTOM_PROPERTIES_URL, DTI_VARIABLES_SCSS_URL],
-                  warnings,
-                  stability: 'alpha',
-                  extra: { versions: dsMeta?.versions ?? undefined },
-                }),
-              },
-              null,
-              2
-            ),
-          },
-        ],
+        content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
       }
     }
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,11 +43,19 @@ export interface ComponentVariant {
 
 // ─── BSI — api/custom_properties.json ────────────────────────────────────────
 
+export type TokenRole = 'bsi-component' | 'bsi-global' | 'dti'
+
+export interface ResolvedHop {
+  name: string
+  role: TokenRole
+  overridable: boolean   // true for --bsi-* (project-overridable at runtime), false for --it-*/$it-* (central, not overridable per-project)
+}
+
 export interface CssToken {
   name: string
   value: string
   valueType: 'token-reference' | 'scss-expression' | 'literal'
-  resolvedVia: string[]
+  resolvedVia: ResolvedHop[]
   valueResolved: string | null
   valueResolvedNote?: string    // present only for scss-expression tokens
   description: string | null
@@ -230,3 +238,4 @@ export interface ComponentFull {
     designersUrl?: string | null
   }
 }
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,9 @@ export interface ComponentVariant {
 export type TokenRole = 'bsi-component' | 'bsi-global' | 'dti'
 
 export interface ResolvedHop {
-  name: string
+  name: string                                  // normalized internal key
+  sourceName: string                            // "$it-spacing-6x" for dti, "--bsi-spacing-m" for bsi-*
+  form: 'css-custom-property' | 'sass-variable'
   role: TokenRole
   overridable: boolean   // true for --bsi-* (project-overridable at runtime), false for --it-*/$it-* (central, not overridable per-project)
 }


### PR DESCRIPTION
Part 4 of the WA3 block (v0.4.0 breaking rename) — the riskiest piece, contains the $it- resolver gate. Builds on refactor/wa3-docs-github-rename (PR3) — branched from it, not from main.

## What changes

- tokens_list_component_vars, tokens_list_globals, tokens_resolve, tokens_find_components, tokens_search — full detail in commit message
- Closes the $it- resolver gate flagged in TODO-20260617.md: tokens_resolve now accepts --bsi-*, --it-*, or the Sass source form $it-*, normalized before lookup. Verified end-to-end via Inspector: $it-spacing-m -> 24px.
- Added a dedicated canary check validating the $it- bridge chain against live upstream sources (BSI root.scss + Design Tokens Italia _variables.scss), promoting this from a manual check to CI-verified.

## Bugs found and fixed along the way (pre-existing, not WA3-related)

- ZCssToken schema was missing valueResolvedNote, which tokens_list_component_vars always set for scss-expression tokens — caused a hard runtime validation failure on any component with such tokens (e.g. accordion). Fixed in schemas.ts.
- A second, deeper bug was found in tokens_search output (--bsi-notification-position-distance resolving to the wrong value due to a duplicate variable-name collision in bsiMap) — NOT fixed in this PR, tracked as a separate hotfix (see follow-up PR against main).

## Not included in this PR

Alpha->beta sweep, mini-site, programmatically derived `ping` array — follow in separate PRs.

## Verification

- [x] `npm run typecheck` clean
- [x] `npm run canary` 17/17 (16 existing + 1 new $it- chain check)
- [x] Functional checks via MCP Inspector CLI, all 5 tools:
  - tokens_resolve($it-spacing-m) -> value: "24px...", gate confirmed closed
  - tokens_list_globals -> 206 bridge pairs, no unexpected nulls
  - tokens_find_components(--it-spacing-m) -> 17 components, correct chains
  - tokens_list_component_vars(accordion) -> structuredContent validates against outputSchema after the ZCssToken fix
  - tokens_search(spacing) -> 113 BSI + 21 global results