### PR TITLE
fix: token resolution bugs found while testing WA3 tokens PR

### DIFF
--- a/src/loaders/tokens.ts
+++ b/src/loaders/tokens.ts
@@ -158,8 +158,15 @@ export async function resolveTokenValues(tokens: CssToken[]): Promise<CssToken[]
     const ref = token.value.match(/^var\((--[a-z0-9-]+)\)/)?.[1]
     if (!ref) return token
 
-    const { value, chain } = resolveChain(token.name, maps.bsiMap, maps.bridge, maps.dtiRaw)
-    return { ...token, valueResolved: value, resolvedVia: chain }
+    // Resolve from the token's own declared reference (ref), not from a
+    // re-lookup of token.name in bsiMap. custom_properties.json can contain
+    // duplicate variable-names across components with different values —
+    // bsiMap is a flat Map keyed by name, so a re-lookup by name can return
+    // a different component's value (last write wins). Starting from `ref`,
+    // read directly from this token's own value field, sidesteps that
+    // ambiguity entirely.
+    const { value, chain } = resolveChain(ref, maps.bsiMap, maps.bridge, maps.dtiRaw)
+    return { ...token, valueResolved: value, resolvedVia: [ref, ...chain] }
   })
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -24,6 +24,7 @@ export const ZCssToken = z.object({
   valueResolved: z.string().nullable(),
   resolvedVia: z.array(z.string()),
   description: z.string().nullable(),
+  valueResolvedNote: z.string().optional(),
 })
 
 // ─── get_component_tokens ─────────────────────────────────────────────────────


### PR DESCRIPTION
Two pre-existing bugs, unrelated to WA3 in cause, both found incidentally while testing tokens_search/tokens_list_component_vars in the WA3 tokens PR. Neither had been exercised with real duplicate-name or scss-expression data through the Inspector before now.

## Bug 1: token resolution used name re-lookup instead of declared ref

resolveTokenValues() extracted `ref` from the token's own `value` field but then resolved via `resolveChain(token.name, ...)` instead of `resolveChain(ref, ...)`. bsiMap is a flat Map keyed by variable-name;
if the same variable-name appears more than once in custom_properties.json across different components with different values, the last one wins in the map — so a name-based re-lookup can silently return the wrong component's resolved chain.

Evidence: find_token("notification") returned two --bsi-notification-position-distance entries with different declared
`value` (var(--bsi-spacing-xxs) vs var(--bsi-spacing-s)) but identical resolvedVia/valueResolved — both pointing at whichever entry happened to be last in bsiMap.

Fix: resolve from `ref` directly instead of re-looking-up `token.name`.

## Bug 2: ZCssToken schema missing valueResolvedNote

get_component_tokens always set valueResolvedNote for scss-expression tokens, but the zod schema never declared the field — causing a hard runtime structuredContent validation failure on any component with scss-expression tokens (e.g. accordion has 4).

## Verification

- [x] typecheck clean, canary 16/16
- [x] find_token("notification") — the two position-distance entries
  now resolve independently and correctly (8px vs 16px)
- [x] get_component_tokens("accordion") — structuredContent validates
  against outputSchema, no regression on non-duplicated tokens